### PR TITLE
[CORE-279] Upgrading Jetty v10 & v11 dependencies to v12.

### DIFF
--- a/jwt-servlet-auth-aws/pom.xml
+++ b/jwt-servlet-auth-aws/pom.xml
@@ -42,13 +42,13 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>${dependency.jetty11}</version>
+            <version>${dependency.jetty12}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${dependency.jetty11}</version>
+            <groupId>org.eclipse.jetty.ee9</groupId>
+            <artifactId>jetty-ee9-servlet</artifactId>
+            <version>${dependency.jetty12}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/AwsElbServer.java
+++ b/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/AwsElbServer.java
@@ -21,10 +21,10 @@ import io.telicent.servlet.auth.jwt.verification.jwks.JwksServer;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
 
 import java.io.IOException;
 import java.util.Base64;

--- a/jwt-servlet-auth-core/pom.xml
+++ b/jwt-servlet-auth-core/pom.xml
@@ -85,14 +85,14 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>${dependency.jetty11}</version>
+            <version>${dependency.jetty12}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${dependency.jetty11}</version>
+            <groupId>org.eclipse.jetty.ee9</groupId>
+            <artifactId>jetty-ee9-servlet</artifactId>
+            <version>${dependency.jetty12}</version>
             <scope>test</scope>
         </dependency>
 

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/verification/jwks/JwksServer.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/verification/jwks/JwksServer.java
@@ -20,10 +20,10 @@ import io.jsonwebtoken.security.JwkSet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
 
 import java.io.IOException;
 

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-jaxrs3-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-jaxrs3-integration-tests/pom.xml
@@ -78,15 +78,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${dependency.jetty11}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-            <version>${dependency.jetty11}</version>
+            <groupId>org.eclipse.jetty.ee9</groupId>
+            <artifactId>jetty-ee9-webapp</artifactId>
+            <version>${dependency.jetty12}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-jaxrs3-integration-tests/src/test/java/io/telicent/servlet/auth/jwt/jaxrs3/examples/TestJaxRS3Application.java
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-jaxrs3-integration-tests/src/test/java/io/telicent/servlet/auth/jwt/jaxrs3/examples/TestJaxRS3Application.java
@@ -21,8 +21,8 @@ import io.telicent.servlet.auth.jwt.testing.AbstractIntegrationTests;
 import io.telicent.servlet.auth.jwt.testing.AbstractServer;
 import jakarta.servlet.ServletContextListener;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.resource.PathResource;
-import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.servlet.ServletRegistration;
 import org.glassfish.grizzly.servlet.WebappContext;
@@ -31,7 +31,6 @@ import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.servlet.ServletProperties;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -67,11 +66,11 @@ public class TestJaxRS3Application extends AbstractIntegrationTests {
     }
 
     @Override
-    protected AbstractServer buildWebXmlApplication(int port, String appName) throws IOException {
+    protected AbstractServer buildWebXmlApplication(int port, String appName) {
         ensureWebAppExists(appName);
 
         Server server = new Server(port);
-        WebAppContext webApp = new WebAppContext(new PathResource(new File("src/test/apps/" + appName)), "/");
+        WebAppContext webApp = new WebAppContext(ResourceFactory.root().newResource(new File("src/test/apps/" + appName).toURI()), "/");
         server.setHandler(webApp);
 
         return new Jetty11JaxRS3Server(server, port);

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet3-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet3-integration-tests/pom.xml
@@ -60,21 +60,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${dependency.jetty10}</version>
+            <groupId>org.eclipse.jetty.ee8</groupId>
+            <artifactId>jetty-ee8-servlet</artifactId>
+            <version>${dependency.jetty12}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${dependency.jetty10}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-            <version>${dependency.jetty10}</version>
+            <groupId>org.eclipse.jetty.ee8</groupId>
+            <artifactId>jetty-ee8-webapp</artifactId>
+            <version>${dependency.jetty12}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet3-integration-tests/src/test/java/io/telicent/servlet/auth/jwt/servlet3/examples/TestServlet3Application.java
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet3-integration-tests/src/test/java/io/telicent/servlet/auth/jwt/servlet3/examples/TestServlet3Application.java
@@ -20,16 +20,15 @@ import io.telicent.servlet.auth.jwt.servlet3.JwtAuthFilter;
 import io.telicent.servlet.auth.jwt.testing.AbstractIntegrationTests;
 import io.telicent.servlet.auth.jwt.testing.AbstractServer;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.FilterHolder;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.util.resource.PathResource;
-import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.ee8.servlet.FilterHolder;
+import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee8.servlet.ServletHandler;
+import org.eclipse.jetty.ee8.servlet.ServletHolder;
+import org.eclipse.jetty.ee8.webapp.WebAppContext;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 
 import javax.servlet.DispatcherType;
 import java.io.File;
-import java.io.IOException;
 import java.util.EnumSet;
 
 public class TestServlet3Application extends AbstractIntegrationTests {
@@ -51,11 +50,11 @@ public class TestServlet3Application extends AbstractIntegrationTests {
     }
 
     @Override
-    protected AbstractServer buildWebXmlApplication(int port, String appName) throws IOException {
+    protected AbstractServer buildWebXmlApplication(int port, String appName) {
         ensureWebAppExists(appName);
 
         Server server = new Server(port);
-        WebAppContext webApp = new WebAppContext(new PathResource(new File("src/test/apps/" + appName)), "/");
+        WebAppContext webApp = new WebAppContext(ResourceFactory.root().newResource(new File("src/test/apps/" + appName).toURI()), "/");
         server.setHandler(webApp);
         return new JettyServlet3Server(server, port);
     }

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet5-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet5-integration-tests/pom.xml
@@ -62,19 +62,19 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>${dependency.jetty11}</version>
+            <version>${dependency.jetty12}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${dependency.jetty11}</version>
+            <groupId>org.eclipse.jetty.ee9</groupId>
+            <artifactId>jetty-ee9-servlet</artifactId>
+            <version>${dependency.jetty12}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-            <version>${dependency.jetty11}</version>
+            <groupId>org.eclipse.jetty.ee9</groupId>
+            <artifactId>jetty-ee9-webapp</artifactId>
+            <version>${dependency.jetty12}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet5-integration-tests/src/test/java/io/telicent/servlet/auth/jwt/servlet5/examples/TestServlet5Application.java
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet5-integration-tests/src/test/java/io/telicent/servlet/auth/jwt/servlet5/examples/TestServlet5Application.java
@@ -20,16 +20,15 @@ import io.telicent.servlet.auth.jwt.servlet5.JwtAuthFilter;
 import io.telicent.servlet.auth.jwt.testing.AbstractIntegrationTests;
 import io.telicent.servlet.auth.jwt.testing.AbstractServer;
 import jakarta.servlet.DispatcherType;
+import org.eclipse.jetty.ee9.servlet.FilterHolder;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.FilterHolder;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.util.resource.PathResource;
-import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.ee9.webapp.WebAppContext;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.EnumSet;
 
 public class TestServlet5Application extends AbstractIntegrationTests {
@@ -49,11 +48,11 @@ public class TestServlet5Application extends AbstractIntegrationTests {
         return new JettyServlet5Server(server, port);
     }
 
-    protected AbstractServer buildWebXmlApplication(int port, String appName) throws IOException {
+    protected AbstractServer buildWebXmlApplication(int port, String appName) {
         ensureWebAppExists(appName);
 
         Server server = new Server(port);
-        WebAppContext webApp = new WebAppContext(new PathResource(new File("src/test/apps/" + appName)), "/");
+        WebAppContext webApp = new WebAppContext(ResourceFactory.root().newResource(new File("src/test/apps/" + appName).toURI()), "/");
         server.setHandler(webApp);
         return new JettyServlet5Server(server, port);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,10 @@
         <dependency.jaxrs31>3.1.0</dependency.jaxrs31>
         <dependency.jersey3>3.1.7</dependency.jersey3>
         <dependency.jjwt>0.12.6</dependency.jjwt>
-        <dependency.jetty10>10.0.21</dependency.jetty10>
-        <dependency.jetty11>11.0.19</dependency.jetty11>
+        <dependency.jetty12>12.0.4</dependency.jetty12>
         <dependency.mockito>5.12.0</dependency.mockito>
-        <dependency.servlet3>3.1.0</dependency.servlet3>
-        <dependency.servlet5>5.0.0</dependency.servlet5>
+        <dependency.servlet3>4.0.1</dependency.servlet3>
+        <dependency.servlet5>6.1.0</dependency.servlet5>
         <dependency.slf4j>2.0.13</dependency.slf4j>
         <dependency.testng>7.10.2</dependency.testng>
     </properties>


### PR DESCRIPTION
Aside from updating the dependencies such that v10 -> ee8 and v11 -> ee9, the only changes required are replacing PathResource constructor which has been deprecated.