### PR TITLE
Revert unintended change to Servlet API versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,8 @@
         <dependency.jjwt>0.12.6</dependency.jjwt>
         <dependency.jetty12>12.0.11</dependency.jetty12>
         <dependency.mockito>5.12.0</dependency.mockito>
-        <dependency.servlet3>4.0.1</dependency.servlet3>
-        <dependency.servlet5>6.1.0</dependency.servlet5>
+        <dependency.servlet3>3.1.0</dependency.servlet3>
+        <dependency.servlet5>5.0.0</dependency.servlet5>
         <dependency.slf4j>2.0.13</dependency.slf4j>
         <dependency.testng>7.10.2</dependency.testng>
     </properties>


### PR DESCRIPTION
Since these libraries are designed to be as portable as possible pin the Servlet APIs versions back to their intended base versions