### PR TITLE
Prevent HTTP splitting in Authentication Challenges

### DIFF
--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/HeaderBasedJwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/HeaderBasedJwtAuthenticationEngine.java
@@ -95,7 +95,8 @@ public abstract class HeaderBasedJwtAuthenticationEngine<TRequest, TResponse>
      * @return Realm
      */
     protected String selectRealm(String defaultRealm) {
-        return StringUtils.isNotBlank(this.realm) ? this.realm : defaultRealm;
+        return JwtHttpConstants.sanitiseHeaderParameterValue(
+                StringUtils.isNotBlank(this.realm) ? this.realm : defaultRealm);
     }
 
     @Override

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/JwtHttpConstants.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/JwtHttpConstants.java
@@ -16,14 +16,46 @@
 package io.telicent.servlet.auth.jwt;
 
 import io.telicent.servlet.auth.jwt.sources.HeaderSource;
+import org.apache.commons.lang3.RegExUtils;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Constants related to HTTP usage in conjunction with JWTs
  */
 public class JwtHttpConstants {
+
+    /**
+     * A regular expression that matches characters that are considered invalid for use in a sanitised HTTP Header
+     * parameter value, this is utilised by the {@link #sanitiseHeaderParameterValue(String)} method.
+     * <p>
+     * This pattern considers anything that is not one of the following as invalid:
+     * </p>
+     * <ul>
+     *     <li>Alphanumeric characters (letters and digits)</li>
+     *     <li>Hyphens ({@code -})</li>
+     *     <li>Underscores {@code _}</li>
+     *     <li>Periods ({@code .}), Commas ({@code ,}) and Semicolons ({@code ;})</li>
+     *     <li>Forward slashes ({@code /})</li>
+     *     <li>Single quotes ({@code '})</li>
+     *     <li>Equals ({@code =}) and Plus ({@code +})</li>
+     *     <li>The basic space character</li>
+     * </ul>
+     */
+    public static final Pattern INVALID_PARAM_CHARACTERS = Pattern.compile("[^\\p{L}\\d\\-_.,;/'=+ ]");
+
+    /**
+     * A regular expression that matches characters that are considered invalid for use in a sanitised HTTP Header
+     * value, this is utilised by the {@link #sanitiseHeader(String)} method.
+     * <p>
+     * This considers anything that is not an acceptable character for {@link #INVALID_PARAM_CHARACTERS}, or a double
+     * quote {@code "}, as invalid.
+     * </p>
+     */
+    public static final Pattern INVALID_HEADER_CHARACTERS = Pattern.compile("[^\\p{L}\\d\\-_.,;/'\"=+ ]");
+
     private JwtHttpConstants() {
     }
 
@@ -41,7 +73,7 @@ public class JwtHttpConstants {
      * The HTTP {@code Bearer} authentication scheme
      */
     public static final String AUTH_SCHEME_BEARER = "Bearer";
-    
+
     /**
      * The realm challenge parameter used in HTTP Authorization challenges
      */
@@ -54,4 +86,32 @@ public class JwtHttpConstants {
             DEFAULT_HEADER_SOURCES =
             List.of(new HeaderSource(JwtHttpConstants.HEADER_AUTHORIZATION, JwtHttpConstants.AUTH_SCHEME_BEARER));
 
+    /**
+     * Sanitises a value that is intended for inclusion in a parameter within an HTTP Header value to avoid
+     * request/response splitting attacks
+     * <p>
+     * A sanitised value consists only of characters not matching the {@link #INVALID_PARAM_CHARACTERS} regular
+     * expression, any other characters are removed from the provided value.
+     * </p>
+     *
+     * @param value Value to sanitise
+     * @return Sanitised values
+     */
+    public static String sanitiseHeaderParameterValue(String value) {
+        return RegExUtils.removeAll(value, INVALID_PARAM_CHARACTERS);
+    }
+
+    /**
+     * Sanitises a value that is intended to be a value for an HTTP Header to avoid request/response splitting attacks
+     * <p>
+     * A sanitised value consists only of characters not matching the {@link #INVALID_HEADER_CHARACTERS} regular
+     * expression, any other characters are removed from the provided value.
+     * </p>
+     *
+     * @param header Header value to sanitise
+     * @return Sanitised values
+     */
+    public static String sanitiseHeader(String header) {
+        return RegExUtils.removeAll(header, INVALID_HEADER_CHARACTERS);
+    }
 }

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/TestJwtHttpConstants.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/TestJwtHttpConstants.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.servlet.auth.jwt;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestJwtHttpConstants {
+
+    @DataProvider(name = "valid")
+    public Object[][] validValues() {
+        return new Object[][] {
+                { "text/plain" },
+                { "text/html;q=1.0,text/xml;q=0.1" },
+                { "sub.domain.com" },
+                { "A human readable string" },
+                { "With, basic; punctuation-characters" },
+                { "foo=1+3" }
+        };
+    }
+
+    @DataProvider(name = "invalid")
+    public Object[][] invalidValues() {
+        return new Object[][] {
+                { "with\nnew line" },
+                { "with\ttabs" },
+                { "foo=\"bar\"" },
+                { "with\\backslashes" },
+                // Note that while " is valid within an HTTP Header value where it is used we generally are using it to
+                // express parameters within an HTTP header value.  Thus, we don't want to allow the values we're
+                // expressing in those parameters to break those parameters.
+                { "realm=\"sub.domain.com\"" }
+        };
+    }
+
+    @Test(dataProvider = "valid")
+    public void givenValidHeaderValue_whenSanitising_thenUnchanged(String value) {
+        // Given and When
+        String sanitised = JwtHttpConstants.sanitiseHeaderParameterValue(value);
+
+        // Then
+        Assert.assertEquals(sanitised, value);
+    }
+
+    @Test(dataProvider = "invalid")
+    public void givenInvalidHeaderValue_whenSanitising_thenChanged(String value) {
+        // Given and When
+        String sanitised = JwtHttpConstants.sanitiseHeaderParameterValue(value);
+
+        // Then
+        Assert.assertNotEquals(sanitised, value);
+    }
+}

--- a/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JaxRs3JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JaxRs3JwtAuthenticationEngine.java
@@ -111,7 +111,7 @@ public class JaxRs3JwtAuthenticationEngine
     @Override
     protected void sendChallenge(ContainerRequestContext request, ContainerResponseContext response,
                                  Challenge challenge) {
-        String realm = selectRealm(getRequestUrl(request));
+        String realm = selectRealm(JwtHttpConstants.sanitiseHeaderParameterValue(getRequestUrl(request)));
         Map<String, String> additionalParams =
                 buildChallengeParameters(challenge.errorCode(), challenge.errorDescription());
         String authChallenge = buildAuthorizationHeader(realm, additionalParams);

--- a/jwt-servlet-auth-servlet3/src/main/java/io/telicent/servlet/auth/jwt/servlet3/Servlet3JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-servlet3/src/main/java/io/telicent/servlet/auth/jwt/servlet3/Servlet3JwtAuthenticationEngine.java
@@ -83,7 +83,7 @@ public class Servlet3JwtAuthenticationEngine
 
     @Override
     protected void sendChallenge(HttpServletRequest request, HttpServletResponse response, Challenge challenge) {
-        String realm = selectRealm(request.getRequestURI());
+        String realm = selectRealm(JwtHttpConstants.sanitiseHeaderParameterValue(request.getRequestURI()));
         Map<String, String> additionalParams =
                 buildChallengeParameters(challenge.errorCode(), challenge.errorDescription());
         response.addHeader(JwtHttpConstants.HEADER_WWW_AUTHENTICATE,

--- a/jwt-servlet-auth-servlet5/src/main/java/io/telicent/servlet/auth/jwt/servlet5/Servlet5JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-servlet5/src/main/java/io/telicent/servlet/auth/jwt/servlet5/Servlet5JwtAuthenticationEngine.java
@@ -83,7 +83,7 @@ public class Servlet5JwtAuthenticationEngine extends
 
     @Override
     protected void sendChallenge(HttpServletRequest request, HttpServletResponse response, Challenge challenge) {
-        String realm = selectRealm(request.getRequestURI());
+        String realm = selectRealm(JwtHttpConstants.sanitiseHeaderParameterValue(request.getRequestURI()));
         Map<String, String> additionalParams = buildChallengeParameters(challenge.errorCode(),
                                                                         challenge.errorDescription());
         response.addHeader(JwtHttpConstants.HEADER_WWW_AUTHENTICATE,


### PR DESCRIPTION
This commit adds additional sanitisation code into the generation of HTTP Authentication Challenges to avoid a theoretical HTTP splitting attack that could occur under a couple of rare circumstances:

- A malicious configuration of the challenge realm
- A server runtime that does not correctly sanitise request URIs