### PR TITLE
Don't send error message direct to user

### DIFF
--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/HeaderBasedJwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/HeaderBasedJwtAuthenticationEngine.java
@@ -34,6 +34,10 @@ import java.util.function.BiConsumer;
 public abstract class HeaderBasedJwtAuthenticationEngine<TRequest, TResponse>
         extends JwtAuthenticationEngine<TRequest, TResponse> {
     /**
+     * A generic error message that is sent when authentication fails unexpectedly
+     */
+    public static final String UNEXPECTED_ERROR_MESSAGE = "Unexpected error during JWT authentication";
+    /**
      * Possible header sources
      */
     protected final List<HeaderSource> headers = new ArrayList<>();

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/JwtAuthenticationEngine.java
@@ -50,14 +50,17 @@ public abstract class JwtAuthenticationEngine<TRequest, TResponse> {
 
     /**
      * Attempts to authenticate a request, returning either an authenticated request object upon success or {@code null}
-     * on failure.  Upon failure the engine will have called its {@link #sendChallenge(Object, Object, Challenge)} or
+     * on failure.
+     * <p>
+     * Upon failure the engine will have called either its {@link #sendChallenge(Object, Object, Challenge)} or
      * {@link #sendError(Object, Throwable)} methods as appropriate so that failure will already have been communicated
      * and the caller of the engine can simply cease any further processing of the request.
+     * </p>
      *
      * @param request  Request
      * @param response Response
      * @param verifier JWT Verifier
-     * @return Authenticated request or {@code null} if authentication failed
+     * @return Authenticated request if successful, or {@code null} if authentication failed
      */
     public final TRequest authenticate(TRequest request, TResponse response, JwtVerifier verifier) {
         try {

--- a/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JaxRs3JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JaxRs3JwtAuthenticationEngine.java
@@ -29,6 +29,8 @@ import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.security.Principal;
 import java.util.Collection;
@@ -138,11 +140,7 @@ public class JaxRs3JwtAuthenticationEngine
     protected void sendError(ContainerResponseContext response, Throwable err) {
         // In a JAX-RS context we can just throw the exception and rely on JAX-RS handling the exception to abort the
         // request processing
-        if (err instanceof RuntimeException) {
-            throw (RuntimeException) err;
-        } else {
-            throw new RuntimeException(err);
-        }
+        throw new RuntimeException(UNEXPECTED_ERROR_MESSAGE, err);
     }
 
     @Override

--- a/jwt-servlet-auth-servlet3/src/main/java/io/telicent/servlet/auth/jwt/servlet3/Servlet3JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-servlet3/src/main/java/io/telicent/servlet/auth/jwt/servlet3/Servlet3JwtAuthenticationEngine.java
@@ -19,12 +19,12 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.telicent.servlet.auth.jwt.HeaderBasedJwtAuthenticationEngine;
 import io.telicent.servlet.auth.jwt.JwtHttpConstants;
-import io.telicent.servlet.auth.jwt.JwtServletConstants;
 import io.telicent.servlet.auth.jwt.challenges.Challenge;
 import io.telicent.servlet.auth.jwt.challenges.TokenCandidate;
-import io.telicent.servlet.auth.jwt.challenges.VerifiedToken;
 import io.telicent.servlet.auth.jwt.sources.HeaderSource;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -36,6 +36,8 @@ import java.util.*;
  */
 public class Servlet3JwtAuthenticationEngine
         extends HeaderBasedJwtAuthenticationEngine<HttpServletRequest, HttpServletResponse> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Servlet3JwtAuthenticationEngine.class);
 
     /**
      * Creates a new authentication engine with default configuration
@@ -98,7 +100,8 @@ public class Servlet3JwtAuthenticationEngine
     @Override
     protected void sendError(HttpServletResponse response, Throwable err) {
         try {
-            response.sendError(500, err.getMessage());
+            response.sendError(500, UNEXPECTED_ERROR_MESSAGE);
+            LOGGER.warn("Unexpected error during JWT Authentication: ", err);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/jwt-servlet-auth-servlet5/src/main/java/io/telicent/servlet/auth/jwt/servlet5/Servlet5JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-servlet5/src/main/java/io/telicent/servlet/auth/jwt/servlet5/Servlet5JwtAuthenticationEngine.java
@@ -27,6 +27,8 @@ import io.telicent.servlet.auth.jwt.sources.HeaderSource;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -36,6 +38,7 @@ import java.util.*;
  */
 public class Servlet5JwtAuthenticationEngine extends
         HeaderBasedJwtAuthenticationEngine<HttpServletRequest, HttpServletResponse> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Servlet5JwtAuthenticationEngine.class);
 
     /**
      * Creates a new authentication engine using default configuration
@@ -98,7 +101,8 @@ public class Servlet5JwtAuthenticationEngine extends
     @Override
     protected void sendError(HttpServletResponse response, Throwable err) {
         try {
-            response.sendError(500, err.getMessage());
+            response.sendError(500, UNEXPECTED_ERROR_MESSAGE);
+            LOGGER.warn("Unexpected error during JWT Authentication: ", err);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
When an unexpected authentication failure occurs send a generic message to the end user and just log the actual error

This addresses the other open CodeQL alert