### PR TITLE
Reduce exclusion warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGE LOG
 
+# 0.17.0
+
+- Filter improvements:
+    - A cache is now used to rate limit the frequency of warnings issued when a request goes to a path that has been
+      excluded from authentication by configuration.  
+      This prevents these warnings from dominating the logs when used on
+      things like health status endpoints that are being regularly pinged by automated monitoring tools.
+    - Improved documentation around filter exclusions
+- Build improvements:
+    - Various build and test dependencies upgraded to latest available
+
 # 0.16.0
 
 - Security fixes:

--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ new PathExclusion("/\\$/status/*");
 ```
 
 Every time an excluded path is requested the filter will log a warning indicating that this is happened, this helps
-developers and administrators spot cases where the exclusions may have been overly broad.  See [Path Exclusion Warnings](#path-exclusion-warnings) for more details.
+developers and administrators spot cases where the exclusions may have been overly broad.  See [Path Exclusion
+Warnings](#path-exclusion-warnings) for more details.
 
 ### Limiting use of Path Exclusions
 

--- a/jwt-servlet-auth-core/pom.xml
+++ b/jwt-servlet-auth-core/pom.xml
@@ -96,6 +96,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.valfirst</groupId>
+            <artifactId>slf4j-test</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/AbstractJwtAuthFilter.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/AbstractJwtAuthFilter.java
@@ -15,10 +15,13 @@
  */
 package io.telicent.servlet.auth.jwt;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -31,6 +34,30 @@ import java.util.List;
 public class AbstractJwtAuthFilter<TRequest, TResponse> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJwtAuthFilter.class);
+
+    /**
+     * Default size of the exclusion warnings cache
+     */
+    protected static final int EXCLUSIONS_CACHE_SIZE = 10;
+    /**
+     * We create a basic cache to control the flow of path exclusion warnings because without this these warnings can
+     * dominate the logs of relatively quiet services if automated monitoring tools are regularly pinging a health
+     * status endpoint (or other equivalent) that's been configured for exclusion and detracts from actual useful
+     * logging from the service.
+     * <p>
+     * Note that we set the cache size intentionally quite small (see {@link #EXCLUSIONS_CACHE_SIZE}) as applications
+     * should generally have very few exclusions, if they have too many paths being excluded then that's most likely a
+     * sign that they are misconfigured.  In that case we want them to be spammed by the warnings so they realise their
+     * mistake!
+     * </p>
+     */
+    protected static final Cache<String, Boolean> EXCLUSION_WARNINGS_CACHE =
+            Caffeine.newBuilder()
+                    .expireAfterWrite(Duration.ofMinutes(15))
+                    .initialCapacity(EXCLUSIONS_CACHE_SIZE)
+                    .maximumSize(
+                            EXCLUSIONS_CACHE_SIZE)
+                    .build();
 
     /**
      * Gets whether the given path is an excluded path to which the filter should not apply
@@ -49,8 +76,14 @@ public class AbstractJwtAuthFilter<TRequest, TResponse> {
 
         boolean excluded = exclusions.stream().anyMatch(e -> e.matches(path));
         if (excluded) {
-            LOGGER.warn("Request to path {} is excluded from JWT Authentication filtering by filter configuration",
-                        path);
+            // Use a cache to prevent these warnings being spammed endlessly, this is especially true when something
+            // like a health status endpoint is excluded from authentication and being regularly hit by automated
+            // monitoring tools
+            if (EXCLUSION_WARNINGS_CACHE.getIfPresent(path) == null) {
+                LOGGER.warn("Request to path {} is excluded from JWT Authentication filtering by filter configuration",
+                            path);
+                EXCLUSION_WARNINGS_CACHE.put(path, Boolean.TRUE);
+            }
         }
         return excluded;
     }

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/TestExclusionWarningCache.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/TestExclusionWarningCache.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.servlet.auth.jwt;
+
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
+import org.slf4j.event.Level;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class TestExclusionWarningCache {
+
+    private final FilterForTest filter = new FilterForTest();
+    private final TestLogger logger = TestLoggerFactory.getTestLogger(AbstractJwtAuthFilter.class);
+
+    @BeforeMethod
+    public void prepareTest() {
+        this.logger.clearAll();
+        this.filter.resetCache();
+    }
+
+    @AfterClass
+    public void teardown() {
+        this.logger.clearAll();
+    }
+
+    private List<String> generatePaths(String basePath, int count) {
+        List<String> paths = new ArrayList<>();
+        for (int i = 1; i <= count; i++) {
+            paths.add(basePath + i);
+        }
+        return paths;
+    }
+
+    private void verifyWarnings(long expectedWarnings) {
+        Assert.assertEquals(countWarningsIssued(), expectedWarnings);
+    }
+
+    private long countWarningsIssued() {
+        return this.logger.getAllLoggingEvents()
+                          .stream()
+                          .filter(e -> e.getLevel() == Level.WARN)
+                          .map(LoggingEvent::getFormattedMessage)
+                          .filter(l -> l.contains("is excluded from JWT Authentication"))
+                          .count();
+    }
+
+    private List<String> findWarningPaths() {
+        return this.logger.getAllLoggingEvents()
+                          .stream()
+                          .filter(e -> e.getLevel() == Level.WARN)
+                          .map(e -> e.getArguments().get(0))
+                          .map(Object::toString)
+                          .toList();
+    }
+
+    @Test
+    public void givenExcludedPath_whenCheckingForExclusion_thenWarningIsIssued() {
+        // Given
+        List<PathExclusion> exclusions = PathExclusion.parsePathPatterns("/healthz");
+        String path = "/healthz";
+
+        // When
+        checkForExclusion(path, exclusions);
+
+        // Then
+        verifyWarnings(1);
+    }
+
+    @Test
+    public void givenExcludedPath_whenCheckingForExclusionMultipleTimes_thenWarningIsIssuedOnlyOnce() {
+        // Given
+        List<PathExclusion> exclusions = PathExclusion.parsePathPatterns("/healthz");
+        String path = "/healthz";
+
+        // When
+        for (int i = 0; i < 100; i++) {
+            checkForExclusion(path, exclusions);
+        }
+
+        // Then
+        verifyWarnings(1);
+    }
+
+    @Test
+    public void givenManyExcludedPaths_whenCheckingForExclusions_thenWarningIsIssuedOnlyOncePerPath() {
+        // Given
+        List<PathExclusion> exclusions = PathExclusion.parsePathPatterns("/status/*");
+        List<String> paths = this.generatePaths("/status/", FilterForTest.EXCLUSIONS_CACHE_SIZE);
+
+        // When
+        checkAllExclusions(paths, exclusions);
+
+        // Then
+        verifyWarnings(paths.size());
+        verifyAtLeastOneWarningPerPath(paths);
+    }
+
+    private void checkAllExclusions(List<String> paths, List<PathExclusion> exclusions) {
+        for (String path : paths) {
+            checkForExclusion(path, exclusions);
+        }
+    }
+
+    private void checkForExclusion(String path, List<PathExclusion> exclusions) {
+        boolean excluded = this.filter.isExcludedPath(path, exclusions);
+        Assert.assertTrue(excluded);
+    }
+
+    private void verifyAtLeastOneWarningPerPath(List<String> paths) {
+        List<String> warningsIssuesFor = findWarningPaths();
+        for (String path : paths) {
+            Assert.assertTrue(warningsIssuesFor.contains(path), "No warning found for path " + path);
+        }
+    }
+
+    @Test
+    public void givenTooManyExcludedPaths_whenCheckingForExclusions_thenSomeWarningsAreReissued() {
+        // Given
+        List<PathExclusion> exclusions = PathExclusion.parsePathPatterns("/status/*");
+        List<String> paths = this.generatePaths("/status/", FilterForTest.EXCLUSIONS_CACHE_SIZE * 2);
+
+        // When
+        // Do this once to ensure every path is warned for at least once
+        checkAllExclusions(paths, exclusions);
+        // Now test a bunch of paths at random to randomly overfill the cache and cause some number of extra exclusion
+        // warnings to be generated
+        Random random = new Random();
+        for (int i = 1; i <= 1000; i++) {
+            checkForExclusion(paths.get(random.nextInt(paths.size())), exclusions);
+        }
+
+        // Then
+        Assert.assertTrue(countWarningsIssued() > paths.size());
+        verifyAtLeastOneWarningPerPath(paths);
+    }
+
+    private static final class FilterForTest extends AbstractJwtAuthFilter<String, String> {
+
+        public void resetCache() {
+            EXCLUSION_WARNINGS_CACHE.invalidateAll();
+        }
+    }
+}

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/TestExclusionWarningCache.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/TestExclusionWarningCache.java
@@ -124,7 +124,7 @@ public class TestExclusionWarningCache {
 
     private void checkForExclusion(String path, List<PathExclusion> exclusions) {
         boolean excluded = this.filter.isExcludedPath(path, exclusions);
-        Assert.assertTrue(excluded);
+        Assert.assertTrue(excluded, "Path " + path + " was not excluded as expected");
     }
 
     private void verifyAtLeastOneWarningPerPath(List<String> paths) {
@@ -146,7 +146,7 @@ public class TestExclusionWarningCache {
         // Now test a bunch of paths at random to randomly overfill the cache and cause some number of extra exclusion
         // warnings to be generated
         Random random = new Random();
-        for (int i = 1; i <= 1000; i++) {
+        for (int i = 1; i <= 10_000; i++) {
             checkForExclusion(paths.get(random.nextInt(paths.size())), exclusions);
         }
 

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/TestPathExclusion.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/TestPathExclusion.java
@@ -51,12 +51,15 @@ public class TestPathExclusion {
                 { "*/" },
                 { "**" },
                 { "*/*" },
-                { " * "}
+                { " * "},
+                { "/*/*" },
+                { "/*/*/*" }
         };
     }
 
     @Test(dataProvider = "excludeAllPatterns", expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*excludes all paths")
-    public void exclusion_invalid_05(String pattern) {
+    public void givenAnExcludeAllPattern_whenCreating_thenIllegalArgumentError(String pattern) {
+        // Given, When and Then
         new PathExclusion(pattern);
     }
 
@@ -132,5 +135,29 @@ public class TestPathExclusion {
     public void exclusion_parsing_05() {
         List<PathExclusion> exclusions = PathExclusion.parsePathPatterns(",  ,  ,");
         Assert.assertEquals(exclusions.size(), 0);
+    }
+
+    @Test
+    public void givenWildcardExclusionWithRegexChars_whenTestingForExclusion_thenFails() {
+        // Given
+        PathExclusion exclusion = new PathExclusion("/$/status/*");
+
+        // When
+        boolean excluded = exclusion.matches("/$/status/health");
+
+        // Then
+        Assert.assertFalse(excluded);
+    }
+
+    @Test
+    public void givenWildcardExclusionWithEscapedRegexChars_whenTestingForExclusion_thenSuccess() {
+        // Given
+        PathExclusion exclusion = new PathExclusion("/\\$/status/*");
+
+        // When
+        boolean excluded = exclusion.matches("/$/status/health");
+
+        // Then
+        Assert.assertTrue(excluded);
     }
 }


### PR DESCRIPTION
This PR adds a new cache into the `AbstractJwtAuthFilter` so that we only issue warnings about excluded paths once per 15 minutes for each unique excluded path.  This should reduce noise for services where exclusions are used to allow unauthenticated access to `/healthz` and similar endpoints that are polled by automated monitoring like K8S health checks.

Cache size is set intentionally small so if an application is misconfigured with too many exclusions the warnings will still regularly appear.

Also generally improved the documentation around how path exclusions work and expanded the test cases based on a quirk recently observed by @TelicentPaul in SCG configuration.