### PR TITLE
Ensure SBOM generation (CORE-852)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,6 +386,7 @@
                 </executions>
                 <configuration>
                     <outputName>${project.artifactId}-${project.version}-bom</outputName>
+                    <skipNotDeployed>false</skipNotDeployed>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Works around buggy interaction between Maven Central and CycloneDX plugins that causes SBOMs to not be generated