### PR TITLE
Adds Role Extraction feature (CORE-951)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # 2.0.0
 
+**NB** This is a major version bump due to breaking changes in some internal APIs that should only affect users that
+create custom authentication engines and providers.  If you are simply using this to enable JWT authentication in your
+applications you should see no functional difference, except that you may wish to add additional configuration to enable
+the new feature detailed below.
+
 - New Role extraction feature:
     - When suitably configured all authentication engines are now able to extract role informations from the verified
       JWT and implement the `isUserInRole(String)` methods appropriately:
@@ -16,14 +21,19 @@
     - **BREAKING**: `AbstractHeaderBasedEngineProvider`'s `createEngine()` method added new `String[]` parameter for
       passing in the configured roles claim (if any)
     - New `RolesHelper` utility in `jwt-servlet-auth-core` to help with extracting and converting the roles information
+    - Please note that no support is provided for actually enforcing that users have specific roles as the details of
+      how applications define which roles are required for different URLs is considered beyond the scope of this
+      library, which is focused on Authentication.  However, exposing the roles information from JWTs (if present)
+      allows consumers of this library to more easily build role based authorization solutions on top of this library.
+- JAX-RS improvements:
+    - **BREAKING** `JwtSecurityContext.isSecure()` now only returns `true` if the authenticated request was received via
+      HTTPS
 - Build improvements:
     - Migrated all deprecated Apache Commons Lang usage to their new APIs
     - Suppressed irrelevant compiler warnings throughout the test suite
-
-**NB**: No support is provided for actually enforcing that users have specific roles as the details of how applications
-define which roles are required for different URLs is considered beyond the scope of this library which is focused on
-the Authentication portion only.  However, exposing the roles information from JWTs (if present) allows consumers of
-this library to more easily build role based authorization solutions on top of this library.
+    - Jackson upgraded to 2.20.0
+    - JJWT upgraded to 0.13.0
+    - Various build and test dependencies upgraded to latest available
 
 # 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGE LOG
 
+# 1.1.0
+
+- Build improvements
+    - Upgraded JJWT to 0.13.0
+    - Various build and test dependencies upgraded to latest available
+
 # 1.0.5
 
 - Build improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # CHANGE LOG
 
+# 2.0.0
+
+- New Role extraction feature:
+    - When suitably configured all authentication engines are now able to extract role informations from the verified
+      JWT and implement the `isUserInRole(String)` methods appropriately:
+         - New `jwt.roles.claim` configuration parameter for supplying a path to the claim containing the roles e.g. a
+           value of `roles` would take the information from the top level `roles` claim, whereas a value of
+           `some.path.roles` would take the information from the nested `roles` claim nested under those other claims
+         - `AuthenticatedHttpServletRequest` now supports checking for user roles
+         - New `JwtSecurityContext` for JAX-RS extracted from previous anonymous inner class and now supports checking
+           for user roles
+    - **BREAKING**: `HeaderBasedJwtAuthenticationEngine`, and derived engines, have a new `String[]` constructor
+      parameter that allows configuring the roles claim
+    - **BREAKING**: `AbstractHeaderBasedEngineProvider`'s `createEngine()` method added new `String[]` parameter for
+      passing in the configured roles claim (if any)
+    - New `RolesHelper` utility in `jwt-servlet-auth-core` to help with extracting and converting the roles information
+- Build improvements:
+    - Migrated all deprecated Apache Commons Lang usage to their new APIs
+    - Suppressed irrelevant compiler warnings throughout the test suite
+
+**NB**: No support is provided for actually enforcing that users have specific roles as the details of how applications
+define which roles are required for different URLs is considered beyond the scope of this library which is focused on
+the Authentication portion only.  However, exposing the roles information from JWTs (if present) allows consumers of
+this library to more easily build role based authorization solutions on top of this library.
+
 # 1.1.0
 
 - Build improvements

--- a/jwt-servlet-auth-aws/pom.xml
+++ b/jwt-servlet-auth-aws/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-aws</artifactId>

--- a/jwt-servlet-auth-aws/pom.xml
+++ b/jwt-servlet-auth-aws/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-aws</artifactId>

--- a/jwt-servlet-auth-aws/pom.xml
+++ b/jwt-servlet-auth-aws/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-aws</artifactId>

--- a/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/AwsElbServer.java
+++ b/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/AwsElbServer.java
@@ -21,6 +21,7 @@ import io.telicent.servlet.auth.jwt.verification.jwks.JwksServer;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
@@ -77,7 +78,7 @@ public class AwsElbServer extends JwksServer {
 
             Jwk<?> jwk = this.jwks.getKeys()
                                   .stream()
-                                  .filter(k -> StringUtils.equals(k.getId(), keyId))
+                                  .filter(k -> Strings.CS.equals(k.getId(), keyId))
                                   .findFirst()
                                   .orElse(null);
 

--- a/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/TestAwsElbKeyResolver.java
+++ b/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/TestAwsElbKeyResolver.java
@@ -18,7 +18,7 @@ package io.telicent.servlet.auth.jwt.verifier.aws;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.InvalidKeyException;
 import io.telicent.servlet.auth.jwt.verification.SignedJwtVerifier;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -57,8 +57,8 @@ public class TestAwsElbKeyResolver {
         SignedJwtVerifier verifier = new SignedJwtVerifier(resolver);
 
         // Then
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), "verificationMethod=Locator"));
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), resolver.toString()));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), "verificationMethod=Locator"));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), resolver.toString()));
     }
 
     @Test

--- a/jwt-servlet-auth-core/pom.xml
+++ b/jwt-servlet-auth-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-core</artifactId>

--- a/jwt-servlet-auth-core/pom.xml
+++ b/jwt-servlet-auth-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-core</artifactId>

--- a/jwt-servlet-auth-core/pom.xml
+++ b/jwt-servlet-auth-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-core</artifactId>

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/HeaderBasedJwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/HeaderBasedJwtAuthenticationEngine.java
@@ -18,12 +18,10 @@ package io.telicent.servlet.auth.jwt;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.RequiredTypeException;
-import io.telicent.servlet.auth.jwt.challenges.VerifiedToken;
 import io.telicent.servlet.auth.jwt.sources.HeaderSource;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
-import java.util.function.BiConsumer;
 
 /**
  * A JWT authentication engine that uses HTTP Headers to find the authentication token
@@ -49,6 +47,10 @@ public abstract class HeaderBasedJwtAuthenticationEngine<TRequest, TResponse>
      * The claim(s) from which to extract the username
      */
     protected final List<String> usernameClaims;
+    /**
+     * The sequence of claim(s) from which to extract roles information
+     */
+    protected final String[] rolesClaim;
 
     /**
      * Creates a new engine
@@ -57,9 +59,13 @@ public abstract class HeaderBasedJwtAuthenticationEngine<TRequest, TResponse>
      * @param realm          Realm to use in challenges
      * @param usernameClaims Username claim(s) from which the username should be extracted.  The first claim that
      *                       contains a non-empty value that is a valid string will be used.
+     * @param rolesClaim     Sequence of claims leading to the roles information within the JWTs, if null/empty then no
+     *                       roles information will be made available.  A length 1 array would indicate a top level
+     *                       claim contains the roles information, a longer array would indicate that a nested claim
+     *                       contains the roles information.
      */
     public HeaderBasedJwtAuthenticationEngine(Collection<HeaderSource> headers, String realm,
-                                              Collection<String> usernameClaims) {
+                                              Collection<String> usernameClaims, String[] rolesClaim) {
         Objects.requireNonNull(headers, "Header sources cannot be null");
         if (headers.isEmpty()) {
             throw new IllegalArgumentException("Header sources cannot be empty");
@@ -67,6 +73,7 @@ public abstract class HeaderBasedJwtAuthenticationEngine<TRequest, TResponse>
         this.headers.addAll(headers);
         this.realm = realm;
         this.usernameClaims = usernameClaims != null ? List.copyOf(usernameClaims) : List.of();
+        this.rolesClaim = rolesClaim;
     }
 
     @Override
@@ -114,6 +121,8 @@ public abstract class HeaderBasedJwtAuthenticationEngine<TRequest, TResponse>
                .append(this.realm)
                .append(", usernameClaims=[")
                .append(StringUtils.join(this.usernameClaims, ", "))
+               .append("], rolesClaim=[")
+               .append(this.rolesClaim != null ? StringUtils.join(this.rolesClaim, ", ") : "")
                .append("]}");
         return builder.toString();
     }

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/JwtHttpConstants.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/JwtHttpConstants.java
@@ -98,7 +98,7 @@ public class JwtHttpConstants {
      * @return Sanitised values
      */
     public static String sanitiseHeaderParameterValue(String value) {
-        return RegExUtils.removeAll(value, INVALID_PARAM_CHARACTERS);
+        return RegExUtils.removeAll((CharSequence) value, INVALID_PARAM_CHARACTERS);
     }
 
     /**
@@ -112,6 +112,6 @@ public class JwtHttpConstants {
      * @return Sanitised values
      */
     public static String sanitiseHeader(String header) {
-        return RegExUtils.removeAll(header, INVALID_HEADER_CHARACTERS);
+        return RegExUtils.removeAll((CharSequence) header, INVALID_HEADER_CHARACTERS);
     }
 }

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/PathExclusion.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/PathExclusion.java
@@ -16,6 +16,7 @@
 package io.telicent.servlet.auth.jwt;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +45,7 @@ public class PathExclusion {
             throw new IllegalArgumentException("Cannot have a path exclusion that excludes all paths");
         }
 
-        this.wildcard = StringUtils.contains(pathPattern, "*");
+        this.wildcard = Strings.CS.contains(pathPattern, "*");
         this.regex = this.wildcard ? parsePathPattern(pathPattern) : null;
         this.pattern = pathPattern;
     }
@@ -120,7 +121,7 @@ public class PathExclusion {
         } else if (this.wildcard) {
             return this.regex.matcher(path).matches();
         } else {
-            return StringUtils.equals(this.pattern, path);
+            return Strings.CS.equals(this.pattern, path);
         }
     }
 }

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/configuration/ConfigurationParameters.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/configuration/ConfigurationParameters.java
@@ -22,7 +22,8 @@ import io.telicent.servlet.auth.jwt.JwtHttpConstants;
  */
 public class ConfigurationParameters {
 
-    private ConfigurationParameters() {}
+    private ConfigurationParameters() {
+    }
 
     /**
      * Parameter for indicating that your application wants to permit multiple different filter configurations to be
@@ -48,9 +49,16 @@ public class ConfigurationParameters {
     public static final String PARAM_HEADER_PREFIXES = "jwt.headers.prefixes";
     /**
      * Parameter for configuring the list of claims that are used to find the username for a user from a verified JWT,
-     * should be given in order of preference
+     * should be a comma separated list e.g. {@code preferred_username,email,sub} where claims are listed in order of
+     * preference
      */
     public static final String PARAM_USERNAME_CLAIMS = "jwt.username.claims";
+    /**
+     * Parameter for configuring the roles claim that is used to find the roles information for a user from a verified
+     * JWT, should be a period separated path to the nested claim, if no period characters are present then assumed to
+     * be a top level claim e.g. {@code roles} or {@code some-claim.roles} would both be acceptable values.
+     */
+    public static final String PARAM_ROLES_CLAIM = "jwt.roles.claim";
     /**
      * Parameter for configuring the realm that will be presented to users who are not authenticated as part of the HTTP
      * challenge

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/configuration/FrozenFilterConfiguration.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/configuration/FrozenFilterConfiguration.java
@@ -107,6 +107,7 @@ public final class FrozenFilterConfiguration<TRequest, TResponse> {
      * @throws RuntimeException Thrown if the provided raw engine is of the wrong type, or no configured engine and no
      *                          default engine provided
      */
+    @SuppressWarnings("unchecked")
     private JwtAuthenticationEngine<TRequest, TResponse> prepareEngine(Object rawEngine,
                                                                        JwtAuthenticationEngine<TRequest, TResponse> defaultEngine) {
         JwtAuthenticationEngine<TRequest, TResponse> engine;
@@ -160,6 +161,7 @@ public final class FrozenFilterConfiguration<TRequest, TResponse> {
      * @param rawPathExclusions The list of exclusions.
      * @return A casting of the object to a list of exclusions.
      */
+    @SuppressWarnings("unchecked")
     private List<PathExclusion> preparePathExclusions(Object rawPathExclusions) {
         if (rawPathExclusions == null) {
             return Collections.emptyList();

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/roles/RolesHelper.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/roles/RolesHelper.java
@@ -105,7 +105,11 @@ public class RolesHelper {
     @SuppressWarnings("unchecked")
     private Object findRawRolesClaim() {
         Map<String, Object> claims = this.jws.getPayload();
-        for (int i = 0; i < this.rolesClaim.length; i++) {
+        for (int i = 0; ; i++) {
+            if (claims == null) {
+                return null;
+            }
+
             Object rawRoles = claims.get(this.rolesClaim[i]);
             if (rawRoles == null || i == this.rolesClaim.length - 1) {
                 return rawRoles;
@@ -114,8 +118,6 @@ public class RolesHelper {
             } else {
                 return null;
             }
-
         }
-        return null;
     }
 }

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/roles/RolesHelper.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/roles/RolesHelper.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.servlet.auth.jwt.roles;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+
+import java.util.*;
+
+/**
+ * A helper for obtaining roles information from a JWT
+ * <p>
+ * Roles information is obtained by extracting the configured claim and converting its value via the protected
+ * {@link #loadRoles(Object)} method.  If your roles information is not provided in a format supported by this method
+ * then you can extend this helper and override that method accordingly.
+ * </p>
+ */
+public class RolesHelper {
+    private final Jws<Claims> jws;
+    private final String[] rolesClaim;
+    private Set<String> roles = null;
+
+    /**
+     * Creates a new roles helper
+     *
+     * @param jws        Verified JWT
+     * @param rolesClaim Roles claim that contains the users roles information
+     */
+    public RolesHelper(Jws<Claims> jws, String[] rolesClaim) {
+        this.jws = Objects.requireNonNull(jws, "JWT cannot be null");
+        this.rolesClaim = rolesClaim;
+    }
+
+    /**
+     * Gets whether the user has the given role
+     *
+     * @param role Role
+     * @return True if they have the given role, false otherwise
+     */
+    public boolean isUserInRole(String role) {
+        if (this.rolesClaim == null || this.rolesClaim.length == 0) {
+            // No roles claim so user not considered to be in any role
+            return false;
+        }
+        if (this.roles == null) {
+            this.roles = loadRoles(findRawRolesClaim());
+        }
+        return this.roles.contains(role);
+    }
+
+    /**
+     * Loads the roles by converting the provided roles claim value
+     * <p>
+     * Provided a non-null value is returned the loaded roles are cached for the lifetime of the security context and
+     * this method will not be called again.
+     * </p>
+     * <p>
+     * This method supports role claims given in the following formats:
+     * </p>
+     * <ol>
+     *     <li>If the claim value is a {@link String} then either return a single role, <strong>UNLESS</strong> the
+     *     values contains a {@code ,} character in which case split the value into multiple roles.</li>
+     *     <li>If the claim value is a {@link Collection} then convert the collection values to strings and use those as
+     *     the roles.</li>
+     *     <li>If the claim value is an array of strings then use that as the roles.</li>
+     *     <li>For any other value return an empty set.</li>
+     * </ol>
+     *
+     * @param rawRoles Raw roles claim value, may be {@code null} if no such claim present in the JWT
+     * @return Loaded roles
+     */
+    protected Set<String> loadRoles(Object rawRoles) {
+        if (rawRoles == null) {
+            return Collections.emptySet();
+        } else if (rawRoles instanceof String singleRole) {
+            if (Strings.CS.contains(singleRole, ",")) {
+                return new HashSet<>(Arrays.asList(StringUtils.split(singleRole, ",")));
+            } else {
+                return Collections.singleton(singleRole);
+            }
+        } else if (rawRoles instanceof Collection<?> roleSet) {
+            return new HashSet<>(roleSet.stream().map(Object::toString).toList());
+        } else if (rawRoles instanceof String[] roleArray) {
+            return new HashSet<>(Arrays.asList(roleArray));
+        } else {
+            return Collections.emptySet();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object findRawRolesClaim() {
+        Map<String, Object> claims = this.jws.getPayload();
+        for (int i = 0; i < this.rolesClaim.length; i++) {
+            Object rawRoles = claims.get(this.rolesClaim[i]);
+            if (rawRoles == null || i == this.rolesClaim.length - 1) {
+                return rawRoles;
+            } else if (rawRoles instanceof Map<?, ?> mapClaim) {
+                claims = (Map<String, Object>) mapClaim;
+            } else {
+                return null;
+            }
+
+        }
+        return null;
+    }
+}

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/sources/HeaderSource.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/sources/HeaderSource.java
@@ -16,6 +16,7 @@
 package io.telicent.servlet.auth.jwt.sources;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 /**
  * Represents an HTTP header based token source
@@ -61,7 +62,7 @@ public class HeaderSource implements TokenSource {
     @Override
     public String getRawToken(String rawValue) {
         if (StringUtils.isNotBlank(this.prefix)) {
-            if (!StringUtils.startsWithIgnoreCase(rawValue, prefix)) {
+            if (!Strings.CI.startsWith(rawValue, prefix)) {
                 return null;
             }
             String rawToken = rawValue.substring(prefix.length());

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/verification/KeyUtils.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/verification/KeyUtils.java
@@ -20,6 +20,7 @@ import io.jsonwebtoken.security.SecurityException;
 import io.telicent.servlet.auth.jwt.errors.KeyLoadException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import javax.crypto.SecretKey;
 import java.io.*;
@@ -227,7 +228,7 @@ public class KeyUtils {
         if (client == null) {
             throw new KeyLoadException("A HTTP Client must be provided to use when loading the JWKS");
         }
-        if (!StringUtils.equalsAny(jwksURI.getScheme(), "http", "https")) {
+        if (!Strings.CS.equalsAny(jwksURI.getScheme(), "http", "https")) {
             throw new KeyLoadException("JWKS URI must use http/https scheme");
         }
         HttpRequest request = HttpRequest.newBuilder(jwksURI).GET().build();

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/verification/jwks/UrlJwksKeyLocator.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/verification/jwks/UrlJwksKeyLocator.java
@@ -23,6 +23,7 @@ import io.jsonwebtoken.security.JwkSet;
 import io.telicent.servlet.auth.jwt.errors.KeyLoadException;
 import io.telicent.servlet.auth.jwt.verification.KeyUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.io.File;
 import java.net.URI;
@@ -106,7 +107,7 @@ public class UrlJwksKeyLocator extends LocatorAdapter<Key> {
      * @return True if a supported scheme, false otherwise
      */
     protected static boolean isSupportedScheme(URI jwksURI) {
-        return StringUtils.equalsAny(jwksURI.getScheme(), SUPPORTED_SCHEMES);
+        return Strings.CS.equalsAny(jwksURI.getScheme(), SUPPORTED_SCHEMES);
     }
 
     @Override
@@ -140,7 +141,7 @@ public class UrlJwksKeyLocator extends LocatorAdapter<Key> {
     protected JwkSet loadJwks() {
         JwkSet jwks;
         try {
-            if (StringUtils.equals(this.jwksURI.getScheme(), "file")) {
+            if (Strings.CS.equals(this.jwksURI.getScheme(), "file")) {
                 // Read in File
                 File f = Paths.get(this.jwksURI).toFile();
                 jwks = KeyUtils.loadJwks(f);
@@ -182,7 +183,7 @@ public class UrlJwksKeyLocator extends LocatorAdapter<Key> {
         // to live with this
         return jwks.getKeys()
                    .stream()
-                   .filter(k -> StringUtils.equals(k.getId(), keyId))
+                   .filter(k -> Strings.CS.equals(k.getId(), keyId))
                    .findFirst()
                    .orElse(null);
     }

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/AbstractHeaderBasedEngineTests.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/AbstractHeaderBasedEngineTests.java
@@ -18,10 +18,9 @@ package io.telicent.servlet.auth.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SignatureException;
 import io.jsonwebtoken.security.WeakKeyException;
-import io.telicent.servlet.auth.jwt.fake.FakeRequest;
 import io.telicent.servlet.auth.jwt.sources.HeaderSource;
 import io.telicent.servlet.auth.jwt.verification.*;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
@@ -45,7 +44,7 @@ public abstract class AbstractHeaderBasedEngineTests<TRequest, TResponse> extend
 
         verifyStatusCode(request, response, 401);
         String challenge = verifyHeaderPresent(request, response, JwtHttpConstants.HEADER_WWW_AUTHENTICATE);
-        Assert.assertFalse(StringUtils.contains(challenge, "error="), "No error code expected");
+        Assert.assertFalse(Strings.CS.contains(challenge, "error="), "No error code expected");
     }
 
     @Test
@@ -59,7 +58,7 @@ public abstract class AbstractHeaderBasedEngineTests<TRequest, TResponse> extend
 
         verifyStatusCode(request, response, 401);
         String challenge = verifyHeaderPresent(request, response, JwtHttpConstants.HEADER_WWW_AUTHENTICATE);
-        Assert.assertFalse(StringUtils.contains(challenge, "error="), "No error code expected");
+        Assert.assertFalse(Strings.CS.contains(challenge, "error="), "No error code expected");
     }
 
     @Test
@@ -456,7 +455,7 @@ public abstract class AbstractHeaderBasedEngineTests<TRequest, TResponse> extend
         // Then
         String debugString = engine.toString();
         for (HeaderSource source : sources) {
-            Assert.assertTrue(StringUtils.contains(debugString, source.toString()));
+            Assert.assertTrue(Strings.CS.contains(debugString, source.toString()));
         }
     }
 
@@ -471,7 +470,7 @@ public abstract class AbstractHeaderBasedEngineTests<TRequest, TResponse> extend
         // Then
         String debugString = engine.toString();
         for (HeaderSource source : sources) {
-            Assert.assertTrue(StringUtils.contains(debugString, source.toString()));
+            Assert.assertTrue(Strings.CS.contains(debugString, source.toString()));
         }
     }
 
@@ -486,7 +485,7 @@ public abstract class AbstractHeaderBasedEngineTests<TRequest, TResponse> extend
         // Then
         String debugString = engine.toString();
         for (String claim : claims) {
-            Assert.assertTrue(StringUtils.contains(debugString, claim));
+            Assert.assertTrue(Strings.CS.contains(debugString, claim));
         }
     }
 

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/AbstractTests.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/AbstractTests.java
@@ -17,7 +17,7 @@ package io.telicent.servlet.auth.jwt;
 
 import io.telicent.servlet.auth.jwt.sources.HeaderSource;
 import io.telicent.servlet.auth.jwt.verification.JwtVerifier;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.testng.Assert;
 
 import java.io.IOException;
@@ -91,7 +91,7 @@ public abstract class AbstractTests<TRequest, TResponse> {
      * @param request        Request
      * @param response       Response
      * @param expectedStatus Expected status
-     * @throws IOException
+     * @throws IOException   Thrown if we can't inspect the response status code
      */
     protected abstract void verifyStatusCode(TRequest request, TResponse response, int expectedStatus) throws
             IOException;
@@ -146,7 +146,7 @@ public abstract class AbstractTests<TRequest, TResponse> {
         if (expectedChallengeContents.length > 0) {
             String challenge = verifyHeaderPresent(request, response, JwtHttpConstants.HEADER_WWW_AUTHENTICATE);
             for (String expectedContent : expectedChallengeContents) {
-                Assert.assertTrue(StringUtils.contains(challenge, expectedContent),
+                Assert.assertTrue(Strings.CS.contains(challenge, expectedContent),
                                   "Expected challenge content " + expectedContent + " not found in Challenge " + challenge);
             }
         }

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/EqualsIgnoreCase.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/EqualsIgnoreCase.java
@@ -15,7 +15,7 @@
  */
 package io.telicent.servlet.auth.jwt;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.mockito.ArgumentMatcher;
 
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
@@ -38,7 +38,7 @@ public class EqualsIgnoreCase implements ArgumentMatcher<String> {
 
     @Override
     public boolean matches(String argument) {
-        return StringUtils.equalsIgnoreCase(this.wanted, argument);
+        return Strings.CI.equals(this.wanted, argument);
     }
 
     @Override

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/challenges/TestChallenge.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/challenges/TestChallenge.java
@@ -16,7 +16,7 @@
 package io.telicent.servlet.auth.jwt.challenges;
 
 import io.telicent.servlet.auth.jwt.OAuth2Constants;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -46,8 +46,8 @@ public class TestChallenge {
 
         // And
         String value = challenge.toString();
-        Assert.assertTrue(StringUtils.contains(value, "401"));
-        Assert.assertTrue(StringUtils.contains(value, OAuth2Constants.ERROR_INVALID_TOKEN));
-        Assert.assertTrue(StringUtils.contains(value, "test"));
+        Assert.assertTrue(Strings.CS.contains(value, "401"));
+        Assert.assertTrue(Strings.CS.contains(value, OAuth2Constants.ERROR_INVALID_TOKEN));
+        Assert.assertTrue(Strings.CS.contains(value, "test"));
     }
 }

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/challenges/TestTokenCandidate.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/challenges/TestTokenCandidate.java
@@ -18,7 +18,7 @@ package io.telicent.servlet.auth.jwt.challenges;
 import io.telicent.servlet.auth.jwt.JwtHttpConstants;
 import io.telicent.servlet.auth.jwt.sources.HeaderSource;
 import io.telicent.servlet.auth.jwt.sources.TokenSource;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -52,9 +52,9 @@ public class TestTokenCandidate {
 
         // And
         String toStringValue = candidate.toString();
-        Assert.assertTrue(StringUtils.contains(toStringValue, TokenCandidate.class.getSimpleName()));
-        Assert.assertTrue(StringUtils.contains(toStringValue, "test"));
-        Assert.assertTrue(StringUtils.contains(toStringValue, source.toString()));
+        Assert.assertTrue(Strings.CS.contains(toStringValue, TokenCandidate.class.getSimpleName()));
+        Assert.assertTrue(Strings.CS.contains(toStringValue, "test"));
+        Assert.assertTrue(Strings.CS.contains(toStringValue, source.toString()));
     }
 
     @Test

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/challenges/TestVerifiedToken.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/challenges/TestVerifiedToken.java
@@ -19,7 +19,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.telicent.servlet.auth.jwt.JwtHttpConstants;
 import io.telicent.servlet.auth.jwt.sources.HeaderSource;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -46,6 +46,7 @@ public class TestVerifiedToken {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void givenCandidateAndVerified_whenConstructingVerifiedToken_thenSuccess_andToStringIsCorrect() {
         // Given
         TokenCandidate candidate = new TokenCandidate(new HeaderSource(JwtHttpConstants.HEADER_AUTHORIZATION, JwtHttpConstants.AUTH_SCHEME_BEARER), "Bearer foo");
@@ -60,7 +61,7 @@ public class TestVerifiedToken {
 
         // And
         String value = token.toString();
-        Assert.assertTrue(StringUtils.contains(value, VerifiedToken.class.getSimpleName()));
-        Assert.assertTrue(StringUtils.contains(value, candidate.toString()));
+        Assert.assertTrue(Strings.CS.contains(value, VerifiedToken.class.getSimpleName()));
+        Assert.assertTrue(Strings.CS.contains(value, candidate.toString()));
     }
 }

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/configuration/TestAutomatedConfiguration.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/configuration/TestAutomatedConfiguration.java
@@ -52,7 +52,8 @@ public class TestAutomatedConfiguration extends AbstractFactoryTests {
                 Map.of(ConfigurationParameters.PARAM_JWKS_URL, EXAMPLE_JWKS_URL,
                        ConfigurationParameters.PARAM_PATH_EXCLUSIONS, "/public/*",
                        ConfigurationParameters.PARAM_HEADER_NAMES, "Authorization",
-                       ConfigurationParameters.PARAM_USERNAME_CLAIMS, "email"));
+                       ConfigurationParameters.PARAM_USERNAME_CLAIMS, "email",
+                       ConfigurationParameters.PARAM_ROLES_CLAIM, "roles"));
 
         // When
         AutomatedConfiguration.configure(config);

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/configuration/TestBadEngineProvider.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/configuration/TestBadEngineProvider.java
@@ -35,7 +35,7 @@ public class TestBadEngineProvider {
 
         @Override
         protected <TRequest, TResponse> JwtAuthenticationEngine<TRequest, TResponse> createEngine(
-                List<HeaderSource> headerSources, String realm, List<String> usernameClaims) {
+                List<HeaderSource> headerSources, String realm, List<String> usernameClaims, String[] rolesClaim) {
             return null;
         }
     }
@@ -44,7 +44,7 @@ public class TestBadEngineProvider {
 
         @Override
         protected <TRequest, TResponse> JwtAuthenticationEngine<TRequest, TResponse> createEngine(
-                List<HeaderSource> headerSources, String realm, List<String> usernameClaims) {
+                List<HeaderSource> headerSources, String realm, List<String> usernameClaims, String[] rolesClaim) {
             throw new RuntimeException("Failed");
         }
     }

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/configuration/TestVerificationFactory.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/configuration/TestVerificationFactory.java
@@ -24,7 +24,7 @@ import io.jsonwebtoken.security.RsaPublicJwk;
 import io.telicent.servlet.auth.jwt.verification.JwtVerifier;
 import io.telicent.servlet.auth.jwt.verification.KeyUtils;
 import io.telicent.servlet.auth.jwt.verification.TestKeyUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
@@ -79,7 +79,7 @@ public class TestVerificationFactory extends AbstractFactoryTests {
         Map<String, String> config = Map.of(ConfigurationParameters.PARAM_ALLOWED_CLOCK_SKEW, "10");
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNull(configured.get());
@@ -94,12 +94,12 @@ public class TestVerificationFactory extends AbstractFactoryTests {
                                             ConfigurationParameters.PARAM_KEY_ALGORITHM, algorithm);
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNotNull(configured.get());
-        Assert.assertTrue(StringUtils.contains(configured.get().toString(), "verificationMethod=PublicKey"));
-        Assert.assertTrue(StringUtils.contains(configured.get().toString(), "fingerprint="));
+        Assert.assertTrue(Strings.CS.contains(configured.get().toString(), "verificationMethod=PublicKey"));
+        Assert.assertTrue(Strings.CS.contains(configured.get().toString(), "fingerprint="));
     }
 
     @Test(dataProvider = "publicKeyAlgorithms")
@@ -111,7 +111,7 @@ public class TestVerificationFactory extends AbstractFactoryTests {
                                             ConfigurationParameters.PARAM_KEY_ALGORITHM, "no-such-algorithm");
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNull(configured.get());
@@ -125,7 +125,7 @@ public class TestVerificationFactory extends AbstractFactoryTests {
         Map<String, String> config = Map.of(ConfigurationParameters.PARAM_PUBLIC_KEY, keyFile.getAbsolutePath());
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNull(configured.get());
@@ -140,7 +140,7 @@ public class TestVerificationFactory extends AbstractFactoryTests {
                                             ConfigurationParameters.PARAM_KEY_ALGORITHM, algorithm);
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNull(configured.get());
@@ -157,11 +157,11 @@ public class TestVerificationFactory extends AbstractFactoryTests {
         Map<String, String> config = Map.of(ConfigurationParameters.PARAM_SECRET_KEY, secretKey.getAbsolutePath());
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNotNull(configured.get());
-        Assert.assertTrue(StringUtils.contains(configured.get().toString(), "verificationMethod=SecretKey"));
+        Assert.assertTrue(Strings.CS.contains(configured.get().toString(), "verificationMethod=SecretKey"));
     }
 
     @Test
@@ -174,7 +174,7 @@ public class TestVerificationFactory extends AbstractFactoryTests {
         Map<String, String> config = Map.of(ConfigurationParameters.PARAM_SECRET_KEY, secretKey.getAbsolutePath());
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNull(configured.get());
@@ -192,7 +192,7 @@ public class TestVerificationFactory extends AbstractFactoryTests {
                                             ConfigurationParameters.PARAM_ALLOWED_CLOCK_SKEW, "10");
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNotNull(configured.get());
@@ -210,12 +210,13 @@ public class TestVerificationFactory extends AbstractFactoryTests {
                                             ConfigurationParameters.PARAM_ALLOWED_CLOCK_SKEW, "not a number");
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNotNull(configured.get());
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T extends PublicKey> File saveJwks(PublicJwk<T> jwks) throws IOException {
         File file = Files.createTempFile("jwks", ".json").toFile();
         try (FileOutputStream output = new FileOutputStream(file)) {
@@ -234,12 +235,12 @@ public class TestVerificationFactory extends AbstractFactoryTests {
         Map<String, String> config = Map.of(ConfigurationParameters.PARAM_JWKS_URL, jwksFile.toURI().toString());
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNotNull(configured.get());
-        Assert.assertTrue(StringUtils.contains(configured.get().toString(), "verificationMethod=Locator"));
-        Assert.assertTrue(StringUtils.contains(configured.get().toString(), "jwksUrl=" + jwksFile.toURI()));
+        Assert.assertTrue(Strings.CS.contains(configured.get().toString(), "verificationMethod=Locator"));
+        Assert.assertTrue(Strings.CS.contains(configured.get().toString(), "jwksUrl=" + jwksFile.toURI()));
     }
 
     @Test
@@ -259,12 +260,12 @@ public class TestVerificationFactory extends AbstractFactoryTests {
         Map<String, String> config = Map.of(ConfigurationParameters.PARAM_JWKS_URL, jwksUri.toString());
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNotNull(configured.get());
-        Assert.assertTrue(StringUtils.contains(configured.get().toString(), "verificationMethod=Locator"));
-        Assert.assertTrue(StringUtils.contains(configured.get().toString(), jwksFile.getAbsolutePath()));
+        Assert.assertTrue(Strings.CS.contains(configured.get().toString(), "verificationMethod=Locator"));
+        Assert.assertTrue(Strings.CS.contains(configured.get().toString(), jwksFile.getAbsolutePath()));
     }
 
     @Test
@@ -274,7 +275,7 @@ public class TestVerificationFactory extends AbstractFactoryTests {
         Map<String, String> config = Map.of(ConfigurationParameters.PARAM_JWKS_URL, "not a valid URL");
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNull(configured.get());
@@ -288,7 +289,7 @@ public class TestVerificationFactory extends AbstractFactoryTests {
         Map<String, String> config = Map.of(ConfigurationParameters.PARAM_JWKS_URL, "no-such-file.json");
 
         // When
-        VerificationFactory.configure(supplierForMap(config), x -> configured.set(x));
+        VerificationFactory.configure(supplierForMap(config), configured::set);
 
         // Then
         Assert.assertNull(configured.get());

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/fake/FakeEngine.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/fake/FakeEngine.java
@@ -19,12 +19,10 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.telicent.servlet.auth.jwt.HeaderBasedJwtAuthenticationEngine;
 import io.telicent.servlet.auth.jwt.JwtHttpConstants;
-import io.telicent.servlet.auth.jwt.JwtServletConstants;
 import io.telicent.servlet.auth.jwt.challenges.Challenge;
 import io.telicent.servlet.auth.jwt.challenges.TokenCandidate;
-import io.telicent.servlet.auth.jwt.challenges.VerifiedToken;
 import io.telicent.servlet.auth.jwt.sources.HeaderSource;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.Collections;
 import java.util.List;
@@ -38,20 +36,20 @@ public class FakeEngine extends HeaderBasedJwtAuthenticationEngine<FakeRequest, 
     }
 
     public FakeEngine(String header, String headerPrefix, String realm, String usernameClaim) {
-        this(List.of(new HeaderSource(header, headerPrefix)), realm, usernameClaim != null ? List.of(usernameClaim) : null);
+        this(List.of(new HeaderSource(header, headerPrefix)), realm, usernameClaim != null ? List.of(usernameClaim) : null, null);
     }
 
-    public FakeEngine(List<HeaderSource> headers, String realm, List<String> usernameClaims) {
-        super(headers, realm, usernameClaims);
+    public FakeEngine(List<HeaderSource> headers, String realm, List<String> usernameClaims, String[] rolesClaim) {
+        super(headers, realm, usernameClaims, rolesClaim);
     }
 
     @Override
     protected boolean hasRequiredParameters(FakeRequest fakeRequest) {
         String[] allowedHeaders =
-                this.headers.stream().map(h -> h.getHeader()).collect(Collectors.toList()).toArray(new String[0]);
+                this.headers.stream().map(HeaderSource::getHeader).collect(Collectors.toList()).toArray(new String[0]);
         return fakeRequest.headers.keySet()
                                   .stream()
-                                  .anyMatch(key -> StringUtils.equalsAnyIgnoreCase(key, allowedHeaders));
+                                  .anyMatch(key -> Strings.CI.equalsAny(key, allowedHeaders));
     }
 
     @Override
@@ -59,7 +57,7 @@ public class FakeEngine extends HeaderBasedJwtAuthenticationEngine<FakeRequest, 
         return this.headers.stream()
                            .flatMap(h -> fakeRequest.headers.entrySet()
                                                             .stream()
-                                                            .filter(e -> StringUtils.equalsIgnoreCase(e.getKey(),
+                                                            .filter(e -> Strings.CI.equals(e.getKey(),
                                                                                                       h.getHeader()))
                                                             .flatMap(e -> e.getValue()
                                                                            .stream()

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/fake/FakeEngineProvider.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/fake/FakeEngineProvider.java
@@ -25,8 +25,9 @@ public class FakeEngineProvider extends AbstractHeaderBasedEngineProvider {
     @Override
     @SuppressWarnings("unchecked")
     protected <TRequest, TResponse> JwtAuthenticationEngine<TRequest, TResponse> createEngine(
-            List<HeaderSource> headerSources, String realm, List<String> usernameClaims) {
-        return (JwtAuthenticationEngine<TRequest, TResponse>) new FakeEngine(headerSources, realm, usernameClaims);
+            List<HeaderSource> headerSources, String realm, List<String> usernameClaims, String[] rolesClaim) {
+        return (JwtAuthenticationEngine<TRequest, TResponse>) new FakeEngine(headerSources, realm, usernameClaims,
+                                                                             rolesClaim);
     }
 
     @Override

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/fake/TestFakeConfigurableFilter.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/fake/TestFakeConfigurableFilter.java
@@ -95,7 +95,7 @@ public class TestFakeConfigurableFilter
     protected JwtAuthenticationEngine<FakeRequest, FakeResponse> createEngine(List<HeaderSource> authHeaders,
                                                                               String realm,
                                                                               List<String> usernameClaims) {
-        return new FakeEngine(authHeaders, realm, usernameClaims);
+        return new FakeEngine(authHeaders, realm, usernameClaims, null);
     }
 
     @Override

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/fake/TestFakeEngine.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/fake/TestFakeEngine.java
@@ -56,7 +56,7 @@ public class TestFakeEngine extends AbstractHeaderBasedEngineTests<FakeRequest, 
     protected JwtAuthenticationEngine<FakeRequest, FakeResponse> createEngine(List<HeaderSource> authHeaders,
                                                                               String realm,
                                                                               List<String> usernameClaims) {
-        return new FakeEngine(authHeaders, realm, usernameClaims);
+        return new FakeEngine(authHeaders, realm, usernameClaims, null);
     }
 
     @Override
@@ -84,7 +84,7 @@ public class TestFakeEngine extends AbstractHeaderBasedEngineTests<FakeRequest, 
 
     private static final class NoHeadersFakeEngine extends FakeEngine {
         public NoHeadersFakeEngine() {
-            super(List.of(), null, null);
+            super(List.of(), null, null, null);
         }
     }
 

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/roles/TestRolesHelper.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/roles/TestRolesHelper.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.servlet.auth.jwt.roles;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+public class TestRolesHelper {
+
+    private static final String[] USER_AND_ADMIN = { "user", "admin" };
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void givenNullToken_whenCreatingHelper_thenNPE() {
+        // Given, When and Then
+        new RolesHelper(null, null);
+    }
+
+    @Test
+    public void givenTokenAndNullRolesClaim_whenUsingHelper_thenUserNotInAnyRoles() {
+        // Given
+        Jws<Claims> jwt = Mockito.mock(Jws.class);
+
+        // When
+        RolesHelper helper = new RolesHelper(jwt, null);
+
+        // Then
+        Assert.assertFalse(helper.isUserInRole("test"));
+    }
+
+    @Test
+    public void givenTokenAndEmptyRolesClaim_whenUsingHelper_thenUserNotInAnyRoles() {
+        // Given
+        Jws<Claims> jwt = Mockito.mock(Jws.class);
+
+        // When
+        RolesHelper helper = new RolesHelper(jwt, new String[0]);
+
+        // Then
+        Assert.assertFalse(helper.isUserInRole("test"));
+    }
+
+    @Test
+    public void givenEmptyTokenAndRolesClaim_whenUsingHelper_thenUserNotInAnyRoles() {
+        // Given
+        Jws<Claims> jwt = Mockito.mock(Jws.class);
+        String[] rolesClaim = new String[] { "roles " };
+
+        // When
+        RolesHelper helper = new RolesHelper(jwt, rolesClaim);
+
+        // Then
+        Assert.assertFalse(helper.isUserInRole("test"));
+    }
+
+    @DataProvider(name = "supportedRolesFormats")
+    private Object[][] supportedRoles() {
+        return new Object[][] {
+                // Single string
+                { "user", new String[] { "user" } },
+                // String with comma separated list of strings
+                { "user,admin", USER_AND_ADMIN },
+                // Collections of strings
+                { List.of("user", "admin"), USER_AND_ADMIN },
+                { Set.of("user", "admin"), USER_AND_ADMIN },
+                // Array of strings
+                { USER_AND_ADMIN, USER_AND_ADMIN },
+                };
+    }
+
+    @Test(dataProvider = "supportedRolesFormats")
+    public void givenTokenWithRoles_whenUsingHelper_thenUserInDeclaredRoles(Object rolesValue, String[] expected) {
+        // Given
+        Jws<Claims> jwt = Mockito.mock(Jws.class);
+        Claims claims = Mockito.mock(Claims.class);
+        when(claims.get("roles")).thenReturn(rolesValue);
+        when(jwt.getPayload()).thenReturn(claims);
+
+        // When
+        RolesHelper helper = new RolesHelper(jwt, new String[] { "roles" });
+
+        // Then
+        for (String role : expected) {
+            Assert.assertTrue(helper.isUserInRole(role));
+        }
+        Assert.assertFalse(helper.isUserInRole("test"));
+    }
+
+    @Test(dataProvider = "supportedRolesFormats")
+    public void givenTokenWithNestedRoles_whenUsingHelper_thenUserInDeclaredRoles(Object rolesValue,
+                                                                                  String[] expected) {
+        // Given
+        Jws<Claims> jwt = Mockito.mock(Jws.class);
+        Claims claims = Mockito.mock(Claims.class);
+        when(claims.get("details")).thenReturn(Map.of("roles", rolesValue));
+        when(jwt.getPayload()).thenReturn(claims);
+
+        // When
+        RolesHelper helper = new RolesHelper(jwt, new String[] { "details", "roles" });
+
+        // Then
+        for (String role : expected) {
+            Assert.assertTrue(helper.isUserInRole(role));
+        }
+        Assert.assertFalse(helper.isUserInRole("test"));
+    }
+
+    @Test(dataProvider = "supportedRolesFormats")
+    public void givenTokenWithDeeplyNestedRoles_whenUsingHelper_thenUserInDeclaredRoles(Object rolesValue,
+                                                                                        String[] expected) {
+        // Given
+        Jws<Claims> jwt = Mockito.mock(Jws.class);
+        Claims claims = Mockito.mock(Claims.class);
+        when(claims.get("some")).thenReturn(Map.of("deep", Map.of("path", rolesValue)));
+        when(jwt.getPayload()).thenReturn(claims);
+
+        // When
+        RolesHelper helper = new RolesHelper(jwt, new String[] { "some", "deep", "path" });
+
+        // Then
+        for (String role : expected) {
+            Assert.assertTrue(helper.isUserInRole(role));
+        }
+        Assert.assertFalse(helper.isUserInRole("test"));
+    }
+
+    @Test(dataProvider = "supportedRolesFormats")
+    public void givenTokenWithDeeplyNestedRolesAtWrongPath_whenUsingHelper_thenUserNotInDeclaredRoles(Object rolesValue,
+                                                                                                      String[] expected) {
+        // Given
+        Jws<Claims> jwt = Mockito.mock(Jws.class);
+        Claims claims = Mockito.mock(Claims.class);
+        when(claims.get("some")).thenReturn(Map.of("other", Map.of("path", rolesValue)));
+        when(jwt.getPayload()).thenReturn(claims);
+
+        // When
+        RolesHelper helper = new RolesHelper(jwt, new String[] { "some", "deep", "path" });
+
+        // Then
+        for (String role : expected) {
+            Assert.assertFalse(helper.isUserInRole(role));
+        }
+        Assert.assertFalse(helper.isUserInRole("test"));
+    }
+
+    @Test(dataProvider = "supportedRolesFormats")
+    public void givenTokenWithDeeplyNestedRolesWronglyNested_whenUsingHelper_thenUserNotInDeclaredRoles(
+            Object rolesValue,
+            String[] expected) {
+        // Given
+        Jws<Claims> jwt = Mockito.mock(Jws.class);
+        Claims claims = Mockito.mock(Claims.class);
+        when(claims.get("some")).thenReturn(Map.of("deep", List.of(Map.of("path", rolesValue))));
+        when(jwt.getPayload()).thenReturn(claims);
+
+        // When
+        RolesHelper helper = new RolesHelper(jwt, new String[] { "some", "deep", "path" });
+
+        // Then
+        for (String role : expected) {
+            Assert.assertFalse(helper.isUserInRole(role));
+        }
+        Assert.assertFalse(helper.isUserInRole("test"));
+    }
+
+    @DataProvider(name = "unsupportedRolesFormats")
+    private Object[][] unsupportedRoles() {
+        return new Object[][] {
+                // Maps are not supported
+                { Map.of("user", "true", "admin", "false") },
+                // Other primitive types not supported
+                { 123 },
+                { true },
+                { 12.3e4 }
+        };
+    }
+
+    @Test(dataProvider = "unsupportedRolesFormats")
+    public void givenTokenWithUnsupportedRolesData_whenUsingHelper_thenUserNotInAnyRoles(Object unsupportedRolesValue) {
+        // Given
+        Jws<Claims> jwt = Mockito.mock(Jws.class);
+        Claims claims = Mockito.mock(Claims.class);
+        when(claims.get("roles")).thenReturn(unsupportedRolesValue);
+        when(jwt.getPayload()).thenReturn(claims);
+
+        // When
+        RolesHelper helper = new RolesHelper(jwt, new String[] { "roles" });
+
+        // Then
+        Assert.assertFalse(helper.isUserInRole("test"));
+    }
+}

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/sources/TestHeaderSource.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/sources/TestHeaderSource.java
@@ -17,6 +17,7 @@ package io.telicent.servlet.auth.jwt.sources;
 
 import io.telicent.servlet.auth.jwt.JwtHttpConstants;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -81,8 +82,8 @@ public class TestHeaderSource {
         String value = source.toString();
 
         // Then
-        Assert.assertTrue(StringUtils.contains(value, source.getHeader()));
-        Assert.assertEquals(StringUtils.contains(value, source.getPrefix()),
+        Assert.assertTrue(Strings.CS.contains(value, source.getHeader()));
+        Assert.assertEquals(Strings.CS.contains(value, source.getPrefix()),
                             StringUtils.isNotBlank(source.getPrefix()));
     }
 }

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/verification/TestSignedVerifier.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/verification/TestSignedVerifier.java
@@ -18,7 +18,7 @@ package io.telicent.servlet.auth.jwt.verification;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Jwks;
 import io.jsonwebtoken.security.SignatureException;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -70,6 +70,7 @@ public class TestSignedVerifier {
         return jws;
     }
 
+    @SuppressWarnings("unchecked")
     private Locator<Key> mockKeyResolver(Key key) {
         Locator<Key> resolver = mock(Locator.class);
         when(resolver.locate(any())).thenReturn(key);
@@ -83,7 +84,7 @@ public class TestSignedVerifier {
         String jwt = Jwts.builder().subject("test").signWith(this.key).compact();
 
         // When and Then
-        verify(parser, jwt);
+        Assert.assertNotNull(verify(parser, jwt));
     }
 
     @Test
@@ -195,8 +196,8 @@ public class TestSignedVerifier {
         SignedJwtVerifier verifier = new SignedJwtVerifier(key);
 
         // Then
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), "verificationMethod=PublicKey"));
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), expectedFingerprint));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), "verificationMethod=PublicKey"));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), expectedFingerprint));
     }
 
     @Test
@@ -208,7 +209,7 @@ public class TestSignedVerifier {
         SignedJwtVerifier verifier = new SignedJwtVerifier(key);
 
         // Then
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), "verificationMethod=SecretKey"));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), "verificationMethod=SecretKey"));
     }
 
     @Test
@@ -220,7 +221,7 @@ public class TestSignedVerifier {
         SignedJwtVerifier verifier = new SignedJwtVerifier(locator);
 
         // Then
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), "verificationMethod=Locator"));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), "verificationMethod=Locator"));
     }
 
     @Test
@@ -232,6 +233,6 @@ public class TestSignedVerifier {
         SignedJwtVerifier verifier = new SignedJwtVerifier(parser);
 
         // Then
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), "verificationMethod=CustomParser"));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), "verificationMethod=CustomParser"));
     }
 }

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/verification/jwks/TestUrlJwksKeyLocator.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/verification/jwks/TestUrlJwksKeyLocator.java
@@ -22,7 +22,7 @@ import io.jsonwebtoken.security.Jwk;
 import io.jsonwebtoken.security.JwkSet;
 import io.telicent.servlet.auth.jwt.verification.SignedJwtVerifier;
 import io.telicent.servlet.auth.jwt.verification.TestKeyUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -264,8 +264,8 @@ public class TestUrlJwksKeyLocator {
         SignedJwtVerifier verifier = new SignedJwtVerifier(new UrlJwksKeyLocator(this.jwksFile));
 
         // Then
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), "verificationMethod=Locator"));
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), "jwksUrl=" + this.jwksFile.toString()));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), "verificationMethod=Locator"));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), "jwksUrl=" + this.jwksFile.toString()));
     }
 
     @Test
@@ -278,8 +278,8 @@ public class TestUrlJwksKeyLocator {
         SignedJwtVerifier verifier = new SignedJwtVerifier(new CachedJwksKeyLocator(this.jwksFile, cacheKeysFor));
 
         // Then
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), "verificationMethod=Locator"));
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), "jwksUrl=" + this.jwksFile.toString()));
-        Assert.assertTrue(StringUtils.contains(verifier.toString(), "cacheKeysFor=" + cacheKeysFor.toString()));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), "verificationMethod=Locator"));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), "jwksUrl=" + this.jwksFile.toString()));
+        Assert.assertTrue(Strings.CS.contains(verifier.toString(), "cacheKeysFor=" + cacheKeysFor.toString()));
     }
 }

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-common-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-common-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-common-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-common-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-common-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-common-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-common-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-common-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-common-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-common-integration-tests/src/test/java/io/telicent/servlet/auth/jwt/testing/AbstractIntegrationTests.java
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-common-integration-tests/src/test/java/io/telicent/servlet/auth/jwt/testing/AbstractIntegrationTests.java
@@ -25,6 +25,7 @@ import io.telicent.servlet.auth.jwt.OAuth2Constants;
 import io.telicent.servlet.auth.jwt.verification.TestKeyUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
@@ -561,7 +562,7 @@ public abstract class AbstractIntegrationTests {
         // Then
         String authHeader = response.headers().firstValue(JwtHttpConstants.HEADER_WWW_AUTHENTICATE).orElse(null);
         Assert.assertNotNull(authHeader);
-        Assert.assertTrue(StringUtils.contains(authHeader, OAuth2Constants.ERROR_INVALID_REQUEST));
+        Assert.assertTrue(Strings.CI.contains(authHeader, OAuth2Constants.ERROR_INVALID_REQUEST));
     }
 
     @Test
@@ -581,6 +582,6 @@ public abstract class AbstractIntegrationTests {
         // Then
         String authHeader = response.headers().firstValue(JwtHttpConstants.HEADER_WWW_AUTHENTICATE).orElse(null);
         Assert.assertNotNull(authHeader);
-        Assert.assertTrue(StringUtils.contains(authHeader, OAuth2Constants.ERROR_INVALID_REQUEST));
+        Assert.assertTrue(Strings.CI.contains(authHeader, OAuth2Constants.ERROR_INVALID_REQUEST));
     }
 }

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-integration-tests-report/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-integration-tests-report/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-integration-tests-report</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-integration-tests-report/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-integration-tests-report/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-integration-tests-report</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-integration-tests-report/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-integration-tests-report/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-integration-tests-report</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-jaxrs3-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-jaxrs3-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-jaxrs3-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-jaxrs3-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-jaxrs3-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-jaxrs3-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-jaxrs3-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-jaxrs3-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-jaxrs3-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet3-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet3-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-servlet3-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet3-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet3-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-servlet3-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet3-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet3-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-servlet3-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet5-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet5-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-servlet5-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet5-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet5-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-servlet5-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet5-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-servlet5-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-integration-tests</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jwt-servlet-auth-servlet5-integration-tests</artifactId>

--- a/jwt-servlet-auth-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-parent</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>jwt-servlet-auth-integration-tests</artifactId>
     <name>Telicent - JWT Servlet Auth - Integration Tests</name>

--- a/jwt-servlet-auth-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-parent</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jwt-servlet-auth-integration-tests</artifactId>
     <name>Telicent - JWT Servlet Auth - Integration Tests</name>

--- a/jwt-servlet-auth-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.public</groupId>
         <artifactId>jwt-servlet-auth-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>jwt-servlet-auth-integration-tests</artifactId>
     <name>Telicent - JWT Servlet Auth - Integration Tests</name>

--- a/jwt-servlet-auth-jaxrs3/pom.xml
+++ b/jwt-servlet-auth-jaxrs3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-jaxrs3</artifactId>

--- a/jwt-servlet-auth-jaxrs3/pom.xml
+++ b/jwt-servlet-auth-jaxrs3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-jaxrs3</artifactId>

--- a/jwt-servlet-auth-jaxrs3/pom.xml
+++ b/jwt-servlet-auth-jaxrs3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-jaxrs3</artifactId>

--- a/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JaxRs3EngineProvider.java
+++ b/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JaxRs3EngineProvider.java
@@ -28,9 +28,10 @@ public class JaxRs3EngineProvider extends AbstractHeaderBasedEngineProvider {
     @Override
     @SuppressWarnings("unchecked")
     protected <TRequest, TResponse> JwtAuthenticationEngine<TRequest, TResponse> createEngine(
-            List<HeaderSource> headerSources, String realm, List<String> usernameClaims) {
+            List<HeaderSource> headerSources, String realm, List<String> usernameClaims, String[] rolesClaim) {
         return (JwtAuthenticationEngine<TRequest, TResponse>) new JaxRs3JwtAuthenticationEngine(headerSources, realm,
-                                                                                                usernameClaims);
+                                                                                                usernameClaims,
+                                                                                                rolesClaim);
     }
 
     @Override

--- a/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JaxRs3JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JaxRs3JwtAuthenticationEngine.java
@@ -81,9 +81,19 @@ public class JaxRs3JwtAuthenticationEngine
     @Override
     protected ContainerRequestContext prepareRequest(ContainerRequestContext request, Jws<Claims> jws,
                                                      String username) {
-        request.setSecurityContext(new JwtSecurityContext(jws, username, Strings.CS.equals(
-                request.getUriInfo().getBaseUri().getScheme(), "https"), null));
+        request.setSecurityContext(new JwtSecurityContext(jws, username, isSecureChannel(request), this.rolesClaim));
         return request;
+    }
+
+    /**
+     * Gets whether the request arrived via a secure channel i.e. HTTPs
+     *
+     * @param request Request
+     * @return True if arrived via a secure channel, false otherwise
+     */
+    protected boolean isSecureChannel(ContainerRequestContext request) {
+        return request.getUriInfo() != null && request.getUriInfo().getBaseUri() != null && Strings.CS.equals(
+                request.getUriInfo().getBaseUri().getScheme(), "https");
     }
 
     @Override

--- a/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JwtSecurityContext.java
+++ b/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JwtSecurityContext.java
@@ -13,43 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.telicent.servlet.auth.jwt.servlet3;
+package io.telicent.servlet.auth.jwt.jaxrs3;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
+import io.telicent.servlet.auth.jwt.JwtHttpConstants;
 import io.telicent.servlet.auth.jwt.roles.RolesHelper;
+import jakarta.ws.rs.core.SecurityContext;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
 import java.security.Principal;
+import java.util.*;
 
 /**
- * An authenticated HTTP Servlet Request, which is a decorator around the original request
+ * A JAX-RS {@link SecurityContext} based upon an authenticated JWT
  */
-public class AuthenticatedHttpServletRequest extends HttpServletRequestWrapper {
-
+public class JwtSecurityContext implements SecurityContext {
     private final Jws<Claims> jws;
+    private final boolean isSecure;
     private final String username;
     private final RolesHelper rolesHelper;
 
     /**
-     * Creates a new authenticated request
+     * Creates a new security context
      *
-     * @param request    Original request
-     * @param jws        Verified JWT
-     * @param username   Username extracted from the JWT
-     * @param rolesClaim Roles claim
+     * @param jws              The verified JWT
+     * @param username         Username extracted from the JWT (if any)
+     * @param wasSecureChannel Whether the request was authenticated on a secure channel i.e. HTTPS
+     * @param rolesClaim       Claim from which to extract the list of roles to use when answering
+     *                         {@link #isUserInRole(String)} calls
      */
-    public AuthenticatedHttpServletRequest(HttpServletRequest request, Jws<Claims> jws, String username,
-                                           String[] rolesClaim) {
-        super(request);
+    public JwtSecurityContext(Jws<Claims> jws, String username, boolean wasSecureChannel, String[] rolesClaim) {
+        this.jws = Objects.requireNonNull(jws, "JWT cannot be null");
         this.username = username;
-        this.jws = jws;
+        this.isSecure = wasSecureChannel;
         this.rolesHelper = createRolesHelper(jws, rolesClaim);
     }
 
     /**
-     * Creates the roles helper used by the {@link #isUserInRole(String)} method
+     * Creates a roles helper
+     * <p>
+     * May be overridden if an implementation needs to override how roles information is extracted from the JWT
+     * </p>
      *
      * @param jws        JWT
      * @param rolesClaim Roles claim
@@ -60,8 +64,8 @@ public class AuthenticatedHttpServletRequest extends HttpServletRequestWrapper {
     }
 
     @Override
-    public String getRemoteUser() {
-        return this.username;
+    public Principal getUserPrincipal() {
+        return () -> this.username;
     }
 
     @Override
@@ -73,8 +77,13 @@ public class AuthenticatedHttpServletRequest extends HttpServletRequestWrapper {
     }
 
     @Override
-    public Principal getUserPrincipal() {
-        return () -> username;
+    public boolean isSecure() {
+        return this.isSecure;
+    }
+
+    @Override
+    public String getAuthenticationScheme() {
+        return JwtHttpConstants.AUTH_SCHEME_BEARER;
     }
 
     /**

--- a/jwt-servlet-auth-jaxrs3/src/test/java/io/telicent/servlet/auth/jwt/jaxrs3/TestJaxRs3Engine.java
+++ b/jwt-servlet-auth-jaxrs3/src/test/java/io/telicent/servlet/auth/jwt/jaxrs3/TestJaxRs3Engine.java
@@ -53,11 +53,11 @@ public class TestJaxRs3Engine
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected ContainerRequestContext createMockRequest(Map<String, String> headers) {
         return mockRequest(TEST_REQUEST_URI, headers);
     }
 
+    @SuppressWarnings("unchecked")
     public static ContainerRequestContext mockRequest(URI requestUri, Map<String, String> headers) {
         ContainerRequestContext request = mock(ContainerRequestContext.class);
         MultivaluedMap<String, String> mockHeaders = mock(MultivaluedMap.class);
@@ -130,13 +130,13 @@ public class TestJaxRs3Engine
                                                                                                       String realm,
                                                                                                       String usernameClaim) {
         return new JaxRs3JwtAuthenticationEngine(List.of(new HeaderSource(authHeader, authHeaderPrefix)), realm,
-                                                 usernameClaim != null ? List.of(usernameClaim) : null);
+                                                 usernameClaim != null ? List.of(usernameClaim) : null, null);
     }
 
     @Override
     protected JwtAuthenticationEngine<ContainerRequestContext, ContainerResponseContext> createEngine(
             List<HeaderSource> authHeaders, String realm, List<String> usernameClaims) {
-        return new JaxRs3JwtAuthenticationEngine(authHeaders, realm, usernameClaims);
+        return new JaxRs3JwtAuthenticationEngine(authHeaders, realm, usernameClaims, null);
     }
 
     @Override
@@ -150,7 +150,7 @@ public class TestJaxRs3Engine
         verifyStatusCode(request, expectedStatus);
     }
 
-    public final static void verifyStatusCode(ContainerRequestContext request, int expectedStatus) {
+    public static void verifyStatusCode(ContainerRequestContext request, int expectedStatus) {
         ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
         verify(request).abortWith(captor.capture());
         Response actualResponse = captor.getValue();
@@ -163,7 +163,7 @@ public class TestJaxRs3Engine
         return verifyHeaderPresent(request, expectedHeader);
     }
 
-    public final static String verifyHeaderPresent(ContainerRequestContext request, String expectedHeader) {
+    public static String verifyHeaderPresent(ContainerRequestContext request, String expectedHeader) {
         ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
         verify(request).abortWith(captor.capture());
         Response actualResponse = captor.getValue();
@@ -178,7 +178,7 @@ public class TestJaxRs3Engine
         return verifyAuthenticatedUser(authenticatedRequest);
     }
 
-    public final static String verifyAuthenticatedUser(ContainerRequestContext authenticatedRequest) {
+    public static String verifyAuthenticatedUser(ContainerRequestContext authenticatedRequest) {
         ArgumentCaptor<SecurityContext> captor = ArgumentCaptor.forClass(SecurityContext.class);
         verify(authenticatedRequest).setSecurityContext(captor.capture());
         SecurityContext context = captor.getValue();

--- a/jwt-servlet-auth-jaxrs3/src/test/java/io/telicent/servlet/auth/jwt/jaxrs3/TestJaxRs3Engine.java
+++ b/jwt-servlet-auth-jaxrs3/src/test/java/io/telicent/servlet/auth/jwt/jaxrs3/TestJaxRs3Engine.java
@@ -109,6 +109,7 @@ public class TestJaxRs3Engine
         when(request.getHeaders()).thenReturn(mockHeaders);
         UriInfo uriInfo = mock(UriInfo.class);
         when(uriInfo.getRequestUri()).thenReturn(requestUri);
+        when(uriInfo.getBaseUri()).thenReturn(URI.create("https://example.org" + requestUri.toString()));
         when(uriInfo.getPath()).thenReturn(requestUri.getPath().substring(1));
         when(request.getUriInfo()).thenReturn(uriInfo);
         return request;

--- a/jwt-servlet-auth-jaxrs3/src/test/java/io/telicent/servlet/auth/jwt/jaxrs3/TestJaxRs3Filter.java
+++ b/jwt-servlet-auth-jaxrs3/src/test/java/io/telicent/servlet/auth/jwt/jaxrs3/TestJaxRs3Filter.java
@@ -61,13 +61,13 @@ public class TestJaxRs3Filter
                                                                                                       String realm,
                                                                                                       String usernameClaim) {
         return new JaxRs3JwtAuthenticationEngine(List.of(new HeaderSource(authHeader, authHeaderPrefix)), realm,
-                                                 usernameClaim != null ? List.of(usernameClaim) : null);
+                                                 usernameClaim != null ? List.of(usernameClaim) : null, null);
     }
 
     @Override
     protected JwtAuthenticationEngine<ContainerRequestContext, ContainerResponseContext> createEngine(
             List<HeaderSource> authHeaders, String realm, List<String> usernameClaims) {
-        return new JaxRs3JwtAuthenticationEngine(authHeaders, realm, usernameClaims);
+        return new JaxRs3JwtAuthenticationEngine(authHeaders, realm, usernameClaims, null);
     }
 
     @Override

--- a/jwt-servlet-auth-servlet3/pom.xml
+++ b/jwt-servlet-auth-servlet3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-servlet3</artifactId>

--- a/jwt-servlet-auth-servlet3/pom.xml
+++ b/jwt-servlet-auth-servlet3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-servlet3</artifactId>

--- a/jwt-servlet-auth-servlet3/pom.xml
+++ b/jwt-servlet-auth-servlet3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-servlet3</artifactId>

--- a/jwt-servlet-auth-servlet3/src/main/java/io/telicent/servlet/auth/jwt/servlet3/Servlet3EngineProvider.java
+++ b/jwt-servlet-auth-servlet3/src/main/java/io/telicent/servlet/auth/jwt/servlet3/Servlet3EngineProvider.java
@@ -28,8 +28,9 @@ public class Servlet3EngineProvider extends AbstractHeaderBasedEngineProvider {
     @Override
     @SuppressWarnings("unchecked")
     protected <TRequest, TResponse> JwtAuthenticationEngine<TRequest, TResponse> createEngine(
-            List<HeaderSource> headerSources, String realm, List<String> usernameClaims) {
+            List<HeaderSource> headerSources, String realm, List<String> usernameClaims, String[] rolesClaim) {
         return (JwtAuthenticationEngine<TRequest, TResponse>) new Servlet3JwtAuthenticationEngine(headerSources, realm,
-                                                                                                  usernameClaims);
+                                                                                                  usernameClaims,
+                                                                                                  rolesClaim);
     }
 }

--- a/jwt-servlet-auth-servlet3/src/main/java/io/telicent/servlet/auth/jwt/servlet3/Servlet3JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-servlet3/src/main/java/io/telicent/servlet/auth/jwt/servlet3/Servlet3JwtAuthenticationEngine.java
@@ -44,7 +44,7 @@ public class Servlet3JwtAuthenticationEngine
      */
     public Servlet3JwtAuthenticationEngine() {
         this(JwtHttpConstants.DEFAULT_HEADER_SOURCES, null,
-             null);
+             null, null);
     }
 
     /**
@@ -53,9 +53,12 @@ public class Servlet3JwtAuthenticationEngine
      * @param headers        Header sources
      * @param realm          Realm
      * @param usernameClaims Username claims
+     * @param rolesClaim     Roles claim
      */
-    public Servlet3JwtAuthenticationEngine(Collection<HeaderSource> headers, String realm, Collection<String> usernameClaims) {
-        super(headers, realm, usernameClaims);
+    public Servlet3JwtAuthenticationEngine(Collection<HeaderSource> headers, String realm,
+                                           Collection<String> usernameClaims,
+                                           String[] rolesClaim) {
+        super(headers, realm, usernameClaims, rolesClaim);
     }
 
     @Override
@@ -80,7 +83,7 @@ public class Servlet3JwtAuthenticationEngine
 
     @Override
     protected HttpServletRequest prepareRequest(HttpServletRequest request, Jws<Claims> jws, String username) {
-        return new AuthenticatedHttpServletRequest(request, jws, username);
+        return new AuthenticatedHttpServletRequest(request, jws, username, this.rolesClaim);
     }
 
     @Override

--- a/jwt-servlet-auth-servlet3/src/test/java/io/telicent/servlet/auth/jwt/servlet3/TestServlet3Engine.java
+++ b/jwt-servlet-auth-servlet3/src/test/java/io/telicent/servlet/auth/jwt/servlet3/TestServlet3Engine.java
@@ -75,13 +75,13 @@ public class TestServlet3Engine extends AbstractHeaderBasedEngineTests<HttpServl
                                                                                             String realm,
                                                                                             String usernameClaim) {
         return new Servlet3JwtAuthenticationEngine(List.of(new HeaderSource(authHeader, authHeaderPrefix)), realm,
-                                                   usernameClaim != null ? List.of(usernameClaim) : null);
+                                                   usernameClaim != null ? List.of(usernameClaim) : null, null);
     }
 
     @Override
     protected JwtAuthenticationEngine<HttpServletRequest, HttpServletResponse> createEngine(
             List<HeaderSource> authHeaders, String realm, List<String> usernameClaims) {
-        return new Servlet3JwtAuthenticationEngine(authHeaders, realm, usernameClaims);
+        return new Servlet3JwtAuthenticationEngine(authHeaders, realm, usernameClaims, null);
     }
 
     @Override

--- a/jwt-servlet-auth-servlet3/src/test/java/io/telicent/servlet/auth/jwt/servlet3/TestServlet3Filter.java
+++ b/jwt-servlet-auth-servlet3/src/test/java/io/telicent/servlet/auth/jwt/servlet3/TestServlet3Filter.java
@@ -112,13 +112,13 @@ public class TestServlet3Filter extends
                                                                                             String realm,
                                                                                             String usernameClaim) {
         return new Servlet3JwtAuthenticationEngine(List.of(new HeaderSource(authHeader, authHeaderPrefix)), realm,
-                                                   usernameClaim != null ? List.of(usernameClaim) : null);
+                                                   usernameClaim != null ? List.of(usernameClaim) : null, null);
     }
 
     @Override
     protected JwtAuthenticationEngine<HttpServletRequest, HttpServletResponse> createEngine(
             List<HeaderSource> authHeaders, String realm, List<String> usernameClaims) {
-        return new Servlet3JwtAuthenticationEngine(authHeaders, realm, usernameClaims);
+        return new Servlet3JwtAuthenticationEngine(authHeaders, realm, usernameClaims, null);
     }
 
     @Override

--- a/jwt-servlet-auth-servlet5/pom.xml
+++ b/jwt-servlet-auth-servlet5/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-servlet5</artifactId>

--- a/jwt-servlet-auth-servlet5/pom.xml
+++ b/jwt-servlet-auth-servlet5/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-servlet5</artifactId>

--- a/jwt-servlet-auth-servlet5/pom.xml
+++ b/jwt-servlet-auth-servlet5/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>jwt-servlet-auth-parent</artifactId>
         <groupId>io.telicent.public</groupId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jwt-servlet-auth-servlet5</artifactId>

--- a/jwt-servlet-auth-servlet5/src/main/java/io/telicent/servlet/auth/jwt/servlet5/Servlet5EngineProvider.java
+++ b/jwt-servlet-auth-servlet5/src/main/java/io/telicent/servlet/auth/jwt/servlet5/Servlet5EngineProvider.java
@@ -28,9 +28,10 @@ public class Servlet5EngineProvider extends AbstractHeaderBasedEngineProvider {
     @Override
     @SuppressWarnings("unchecked")
     protected <TRequest, TResponse> JwtAuthenticationEngine<TRequest, TResponse> createEngine(
-            List<HeaderSource> headerSources, String realm, List<String> usernameClaims) {
+            List<HeaderSource> headerSources, String realm, List<String> usernameClaims, String[] rolesClaim) {
         return (JwtAuthenticationEngine<TRequest, TResponse>) new Servlet5JwtAuthenticationEngine(headerSources, realm,
-                                                                                                  usernameClaims);
+                                                                                                  usernameClaims,
+                                                                                                  rolesClaim);
     }
 
     @Override

--- a/jwt-servlet-auth-servlet5/src/main/java/io/telicent/servlet/auth/jwt/servlet5/Servlet5JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-servlet5/src/main/java/io/telicent/servlet/auth/jwt/servlet5/Servlet5JwtAuthenticationEngine.java
@@ -19,10 +19,8 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.telicent.servlet.auth.jwt.HeaderBasedJwtAuthenticationEngine;
 import io.telicent.servlet.auth.jwt.JwtHttpConstants;
-import io.telicent.servlet.auth.jwt.JwtServletConstants;
 import io.telicent.servlet.auth.jwt.challenges.Challenge;
 import io.telicent.servlet.auth.jwt.challenges.TokenCandidate;
-import io.telicent.servlet.auth.jwt.challenges.VerifiedToken;
 import io.telicent.servlet.auth.jwt.sources.HeaderSource;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -36,16 +34,15 @@ import java.util.*;
 /**
  * A JSON Web Token (JWT) authentication engine for use with {@code jakarta.servlet} based applications
  */
-public class Servlet5JwtAuthenticationEngine extends
-        HeaderBasedJwtAuthenticationEngine<HttpServletRequest, HttpServletResponse> {
+public class Servlet5JwtAuthenticationEngine
+        extends HeaderBasedJwtAuthenticationEngine<HttpServletRequest, HttpServletResponse> {
     private static final Logger LOGGER = LoggerFactory.getLogger(Servlet5JwtAuthenticationEngine.class);
 
     /**
      * Creates a new authentication engine using default configuration
      */
     public Servlet5JwtAuthenticationEngine() {
-        this(JwtHttpConstants.DEFAULT_HEADER_SOURCES, null,
-             null);
+        this(JwtHttpConstants.DEFAULT_HEADER_SOURCES, null, null, null);
     }
 
     /**
@@ -54,9 +51,11 @@ public class Servlet5JwtAuthenticationEngine extends
      * @param headers        Header sources
      * @param realm          Realm
      * @param usernameClaims Username claims
+     * @param rolesClaim     Roles claim
      */
-    public Servlet5JwtAuthenticationEngine(Collection<HeaderSource> headers, String realm, Collection<String> usernameClaims) {
-        super(headers, realm, usernameClaims);
+    public Servlet5JwtAuthenticationEngine(Collection<HeaderSource> headers, String realm,
+                                           Collection<String> usernameClaims, String[] rolesClaim) {
+        super(headers, realm, usernameClaims, rolesClaim);
     }
 
     @Override
@@ -87,10 +86,9 @@ public class Servlet5JwtAuthenticationEngine extends
     @Override
     protected void sendChallenge(HttpServletRequest request, HttpServletResponse response, Challenge challenge) {
         String realm = selectRealm(JwtHttpConstants.sanitiseHeaderParameterValue(request.getRequestURI()));
-        Map<String, String> additionalParams = buildChallengeParameters(challenge.errorCode(),
-                                                                        challenge.errorDescription());
-        response.addHeader(JwtHttpConstants.HEADER_WWW_AUTHENTICATE,
-                           buildAuthorizationHeader(realm, additionalParams));
+        Map<String, String> additionalParams =
+                buildChallengeParameters(challenge.errorCode(), challenge.errorDescription());
+        response.addHeader(JwtHttpConstants.HEADER_WWW_AUTHENTICATE, buildAuthorizationHeader(realm, additionalParams));
         try {
             response.sendError(challenge.statusCode());
         } catch (IOException e) {

--- a/jwt-servlet-auth-servlet5/src/test/java/io/telicent/servlet/auth/jwt/servlet5/TestServlet5Engine.java
+++ b/jwt-servlet-auth-servlet5/src/test/java/io/telicent/servlet/auth/jwt/servlet5/TestServlet5Engine.java
@@ -74,13 +74,13 @@ public class TestServlet5Engine extends AbstractHeaderBasedEngineTests<HttpServl
                                                                                             String realm,
                                                                                             String usernameClaim) {
         return new Servlet5JwtAuthenticationEngine(List.of(new HeaderSource(authHeader, authHeaderPrefix)), realm,
-                                                   usernameClaim != null ? List.of(usernameClaim) : null);
+                                                   usernameClaim != null ? List.of(usernameClaim) : null, null);
     }
 
     @Override
     protected JwtAuthenticationEngine<HttpServletRequest, HttpServletResponse> createEngine(
             List<HeaderSource> authHeaders, String realm, List<String> usernameClaims) {
-        return new Servlet5JwtAuthenticationEngine(authHeaders, realm, usernameClaims);
+        return new Servlet5JwtAuthenticationEngine(authHeaders, realm, usernameClaims, null);
     }
 
     @Override

--- a/jwt-servlet-auth-servlet5/src/test/java/io/telicent/servlet/auth/jwt/servlet5/TestServlet5Filter.java
+++ b/jwt-servlet-auth-servlet5/src/test/java/io/telicent/servlet/auth/jwt/servlet5/TestServlet5Filter.java
@@ -118,13 +118,13 @@ public class TestServlet5Filter extends
                                                                                             String realm,
                                                                                             String usernameClaim) {
         return new Servlet5JwtAuthenticationEngine(List.of(new HeaderSource(authHeader, authHeaderPrefix)), realm,
-                                                   usernameClaim != null ? List.of(usernameClaim) : null);
+                                                   usernameClaim != null ? List.of(usernameClaim) : null, null);
     }
 
     @Override
     protected JwtAuthenticationEngine<HttpServletRequest, HttpServletResponse> createEngine(
             List<HeaderSource> authHeaders, String realm, List<String> usernameClaims) {
-        return new Servlet5JwtAuthenticationEngine(authHeaders, realm, usernameClaims);
+        return new Servlet5JwtAuthenticationEngine(authHeaders, realm, usernameClaims, null);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.telicent.public</groupId>
     <artifactId>jwt-servlet-auth-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <modules>
         <module>jwt-servlet-auth-core</module>
         <module>jwt-servlet-auth-jaxrs3</module>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.telicent.public</groupId>
     <artifactId>jwt-servlet-auth-parent</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.1.0</version>
     <modules>
         <module>jwt-servlet-auth-core</module>
         <module>jwt-servlet-auth-jaxrs3</module>
@@ -50,7 +50,7 @@
         <connection>scm:git:https://github.com/telicent-oss/jwt-servlet-auth</connection>
         <developerConnection>scm:git:ssh://git@github.com/telicent-oss/jwt-servlet-auth</developerConnection>
         <url>https://github.com/telicent-oss/jwt-servlet-auth</url>
-        <tag>HEAD</tag>
+        <tag>1.1.0</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.telicent.public</groupId>
     <artifactId>jwt-servlet-auth-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <modules>
         <module>jwt-servlet-auth-core</module>
         <module>jwt-servlet-auth-jaxrs3</module>
@@ -50,7 +50,7 @@
         <connection>scm:git:https://github.com/telicent-oss/jwt-servlet-auth</connection>
         <developerConnection>scm:git:ssh://git@github.com/telicent-oss/jwt-servlet-auth</developerConnection>
         <url>https://github.com/telicent-oss/jwt-servlet-auth</url>
-        <tag>1.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
This PR adds new functionality to allow configuring a roles claim from which roles information is extracted from the JWT and exposed in the resulting Servlet `HttpServletRequest` or JAX-RS request `SecurityContext` as appropriate.