### PR TITLE
Make PathExclusion more usable (CORE-962)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGE LOG
 
+# 2.0.1
+
+- Core improvements:
+    - `PathExclusion` class now implements `toString()`, `hashCode()` and `equals()` methods properly
+- Build and test improvements:
+    - Apache Commons Lang upgraded to 3.19.0
+    - Various build and test dependencies upgraded to latest available
+
 # 2.0.0
 
 **NB** This is a major version bump due to breaking changes in some internal APIs that should only affect users that

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/PathExclusion.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/PathExclusion.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.Strings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -57,14 +58,16 @@ public class PathExclusion {
      * @return List of path exclusions
      */
     public static List<PathExclusion> parsePathPatterns(String rawPathPatterns) {
-        if (StringUtils.isBlank(rawPathPatterns))
+        if (StringUtils.isBlank(rawPathPatterns)) {
             return Collections.emptyList();
+        }
 
         String[] rawPatterns = StringUtils.split(rawPathPatterns, ",");
         List<PathExclusion> exclusions = new ArrayList<>();
         for (String rawPattern : rawPatterns) {
-            if (StringUtils.isBlank(rawPattern))
+            if (StringUtils.isBlank(rawPattern)) {
                 continue;
+            }
             exclusions.add(new PathExclusion(rawPattern));
         }
         return exclusions;
@@ -123,5 +126,30 @@ public class PathExclusion {
         } else {
             return Strings.CS.equals(this.pattern, path);
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.wildcard, this.pattern);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof PathExclusion other) {
+            return this.wildcard == other.wildcard && Objects.equals(this.pattern, other.pattern);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "PathExclusion{wildcard=" + this.wildcard + ", pattern=" + this.pattern + "}";
     }
 }


### PR DESCRIPTION
As discovered while trying to reuse the path matching capabilities of PathExclusion elsewhere there was no `equals()`, `hashCode()` or `toString()` present on the class meaning you couldn't use it as a `Map` key.

This PR adds those methods and unit test coverage for them

# Related Issues

- Needed to make progress on CORE-962