### PR TITLE
Fix not clearing Logging MDC of username in all cases (CORE-1306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGE LOG
 
+# 4.1.1
+
+- Core improvements:
+    - Fixed an edge case bug where in some circumstances the Logging Context (MDC) did not properly clear the 
+      authenticated username at the conclusion of a request which could result in subsequent logging statements 
+      incorrectly being attributed to the wrong username
+- Build improvements:
+    - SLF4J upgraded to 2.0.18
+    - Various build and test dependencies upgraded to latest available
+
 # 4.1.0
 
 - Core improvements:

--- a/jwt-servlet-auth-core/pom.xml
+++ b/jwt-servlet-auth-core/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
-            <version>3.0.3</version>
+            <version>${dependency.slf4j-test}</version>
             <scope>test</scope>
         </dependency>
 

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/AbstractConfigurableJwtAuthFilter.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/AbstractConfigurableJwtAuthFilter.java
@@ -123,7 +123,7 @@ public abstract class AbstractConfigurableJwtAuthFilter<TRequest, TResponse>
      */
     public final void doFilter(TRequest request, TResponse response, BiConsumer<TRequest, TResponse> onSuccess) {
         this.lastAuthenticatedRequest = null;
-        MDC.put(JwtLoggingConstants.MDC_JWT_USER, null);
+        MDC.remove(JwtLoggingConstants.MDC_JWT_USER);
 
         if (this.config.getExclusions() == null) {
             this.config.tryFreezeExclusionsConfiguration(

--- a/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/JwtAuthenticationEngine.java
+++ b/jwt-servlet-auth-core/src/main/java/io/telicent/servlet/auth/jwt/JwtAuthenticationEngine.java
@@ -70,7 +70,7 @@ public abstract class JwtAuthenticationEngine<TRequest, TResponse> {
      */
     public final TRequest authenticate(TRequest request, TResponse response, JwtVerifier verifier) {
         try {
-            MDC.put(JwtLoggingConstants.MDC_JWT_USER, null);
+            MDC.remove(JwtLoggingConstants.MDC_JWT_USER);
             if (!hasRequiredParameters(request)) {
                 // No authentication parameters provided so abort immediately
                 sendChallenge(request, response, new Challenge(401, "", noParametersMessage()));
@@ -148,6 +148,8 @@ public abstract class JwtAuthenticationEngine<TRequest, TResponse> {
 
             // If we reach here then at least one token was considered valid, so we go ahead and prepare an
             // authenticated request that records the authenticated user identity
+            // We also ensure that we put the username in the logging context so loggers can be configured to include
+            // the authenticated username in the log pattern
             MDC.put(JwtLoggingConstants.MDC_JWT_USER, username);
             setRequestAttribute(request, JwtServletConstants.REQUEST_ATTRIBUTE_SOURCE, jws.candidateToken().source());
             setRequestAttribute(request, JwtServletConstants.REQUEST_ATTRIBUTE_RAW_JWT,

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/AbstractFilterTests.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/AbstractFilterTests.java
@@ -20,6 +20,7 @@ import io.telicent.servlet.auth.jwt.verification.FakeTokenVerifier;
 import io.telicent.servlet.auth.jwt.verification.InvalidTokenVerifier;
 import io.telicent.servlet.auth.jwt.verification.JwtVerifier;
 import io.telicent.servlet.auth.jwt.verification.SubjectlessTokenVerifier;
+import org.slf4j.MDC;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -70,7 +71,8 @@ public abstract class AbstractFilterTests<TRequest, TResponse, TFilter extends A
 
     /**
      * Gets the authenticated user (if any)
-     * @param filter Filter
+     *
+     * @param filter  Filter
      * @param request Request
      * @return Authenticated user, or {@code null} if not authenticated
      */
@@ -175,7 +177,8 @@ public abstract class AbstractFilterTests<TRequest, TResponse, TFilter extends A
     }
 
     @Test
-    public void givenWildcardPathExclusion_whenFilteringForMatchingPath_thenNoChallenge_andNonExcludedPathsAreRejected() throws IOException {
+    public void givenWildcardPathExclusion_whenFilteringForMatchingPath_thenNoChallenge_andNonExcludedPathsAreRejected() throws
+            IOException {
         // Given
         TFilter filter =
                 createFilter(createEngine(), new FakeTokenVerifier(), PathExclusion.parsePathPatterns("/status/*"));
@@ -196,7 +199,8 @@ public abstract class AbstractFilterTests<TRequest, TResponse, TFilter extends A
     }
 
     @Test
-    public void givenPathExclusions_whenFilteringForNonExcludedPath_thenRejected_andRequestsWithAuthPermitted() throws IOException {
+    public void givenPathExclusions_whenFilteringForNonExcludedPath_thenRejected_andRequestsWithAuthPermitted() throws
+            IOException {
         // Given
         TFilter filter =
                 createFilter(createEngine(), new FakeTokenVerifier(), PathExclusion.parsePathPatterns("/status/*"));
@@ -228,5 +232,17 @@ public abstract class AbstractFilterTests<TRequest, TResponse, TFilter extends A
 
         // Then
         Assert.assertEquals(getAuthenticatedUser(filter, request), "foo");
+    }
+
+    @Test
+    public void givenLoggingContext_whenFilteringValidRequest_thenLoggingContextUpdated() {
+        // Given
+        MDC.put(JwtLoggingConstants.MDC_JWT_USER, "other");
+
+        // When
+        givenValidToken_whenFiltering_thenAuthenticated();
+
+        // Then
+        Assert.assertNull(MDC.get(JwtLoggingConstants.MDC_JWT_USER));
     }
 }

--- a/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/fake/TestFakeConfigurableFilter.java
+++ b/jwt-servlet-auth-core/src/test/java/io/telicent/servlet/auth/jwt/fake/TestFakeConfigurableFilter.java
@@ -21,6 +21,7 @@ import io.telicent.servlet.auth.jwt.configuration.MapRuntimeConfigAdaptor;
 import io.telicent.servlet.auth.jwt.configuration.RuntimeConfigurationAdaptor;
 import io.telicent.servlet.auth.jwt.sources.HeaderSource;
 import io.telicent.servlet.auth.jwt.verification.JwtVerifier;
+import org.slf4j.MDC;
 import org.testng.Assert;
 
 import java.io.IOException;
@@ -58,7 +59,9 @@ public class TestFakeConfigurableFilter
 
     @Override
     protected void invokeFilter(FakeConfigurableFilter filter, FakeRequest fakeRequest, FakeResponse fakeResponse) {
-        filter.doFilter(fakeRequest, fakeResponse, (authenticatedRequest, authenticatedResponse) -> {});
+        filter.doFilter(fakeRequest, fakeResponse, (authenticatedRequest, authenticatedResponse) -> {
+            MDC.remove(JwtLoggingConstants.MDC_JWT_USER);
+        });
     }
 
     @Override

--- a/jwt-servlet-auth-jaxrs3/pom.xml
+++ b/jwt-servlet-auth-jaxrs3/pom.xml
@@ -62,7 +62,13 @@
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-grizzly2-servlet</artifactId>
-            <version>3.1.11</version>
+            <version>${dependency.jersey3}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.valfirst</groupId>
+            <artifactId>slf4j-test</artifactId>
+            <version>${dependency.slf4j-test}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JwtAuthFilter.java
+++ b/jwt-servlet-auth-jaxrs3/src/main/java/io/telicent/servlet/auth/jwt/jaxrs3/JwtAuthFilter.java
@@ -23,6 +23,7 @@ import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.ext.Provider;
 import org.slf4j.Logger;
@@ -38,7 +39,7 @@ import java.util.function.Function;
 @Provider
 @Priority(Priorities.AUTHENTICATION)
 public class JwtAuthFilter extends AbstractJwtAuthFilter<ContainerRequestContext, ContainerResponseContext>
-        implements ContainerRequestFilter {
+        implements ContainerRequestFilter, ContainerResponseFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JwtAuthFilter.class);
 
@@ -60,7 +61,9 @@ public class JwtAuthFilter extends AbstractJwtAuthFilter<ContainerRequestContext
 
     @Override
     public void filter(ContainerRequestContext request) throws IOException {
-        MDC.put(JwtLoggingConstants.MDC_JWT_USER, null);
+        // Reset the logging context user at the start of filtering to ensure that the logging context doesn't contain a
+        // username unless we successfully authenticate this request
+        MDC.remove(JwtLoggingConstants.MDC_JWT_USER);
 
         if (this.config.getExclusions() == null) {
             this.config.tryFreezeExclusionsConfiguration(
@@ -95,5 +98,13 @@ public class JwtAuthFilter extends AbstractJwtAuthFilter<ContainerRequestContext
         if (this.config.getEngine().authenticate(request, null, this.config.getVerifier()) == null) {
             LOGGER.warn("Request to {} rejected as unauthenticated", request.getUriInfo().getRequestUri().toString());
         }
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        // NB - It's important that we explicitly remove the user from the Logging MDC upon completion of request
+        //      processing otherwise a subsequent request that fails prior to this filter in the JAX-RS request
+        //      processing could be incorrectly logged against the successfully authenticated user for this request
+        MDC.remove(JwtLoggingConstants.MDC_JWT_USER);
     }
 }

--- a/jwt-servlet-auth-jaxrs3/src/test/java/io/telicent/servlet/auth/jwt/jaxrs3/TestJaxRs3Filter.java
+++ b/jwt-servlet-auth-jaxrs3/src/test/java/io/telicent/servlet/auth/jwt/jaxrs3/TestJaxRs3Filter.java
@@ -134,7 +134,10 @@ public class TestJaxRs3Filter
     protected void invokeFilter(JwtAuthFilter filter, ContainerRequestContext containerRequestContext,
                                 ContainerResponseContext containerResponseContext) {
         try {
+            // JAX-RS filter is a request and response filter so would get invoked twice at the different stages of
+            // JAX-RS request processing
             filter.filter(containerRequestContext);
+            filter.filter(containerRequestContext, containerResponseContext);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/jwt-servlet-auth-servlet3/pom.xml
+++ b/jwt-servlet-auth-servlet3/pom.xml
@@ -47,6 +47,12 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.valfirst</groupId>
+            <artifactId>slf4j-test</artifactId>
+            <version>${dependency.slf4j-test}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jwt-servlet-auth-servlet3/src/main/java/io/telicent/servlet/auth/jwt/servlet3/JwtAuthFilter.java
+++ b/jwt-servlet-auth-servlet3/src/main/java/io/telicent/servlet/auth/jwt/servlet3/JwtAuthFilter.java
@@ -17,6 +17,8 @@ package io.telicent.servlet.auth.jwt.servlet3;
 
 import io.telicent.servlet.auth.jwt.AbstractConfigurableJwtAuthFilter;
 import io.telicent.servlet.auth.jwt.JwtAuthenticationEngine;
+import io.telicent.servlet.auth.jwt.JwtLoggingConstants;
+import org.slf4j.MDC;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
@@ -49,6 +51,10 @@ public class JwtAuthFilter extends AbstractConfigurableJwtAuthFilter<HttpServlet
                 filterChain.doFilter(req, resp);
             } catch (Throwable e) {
                 throw new RuntimeException(e);
+            } finally {
+                // Ensure we remove the authenticated user from the logging context at the end of request processing
+                // otherwise it could leak to subsequent requests and cause them to be logged against the wrong user
+                MDC.remove(JwtLoggingConstants.MDC_JWT_USER);
             }
         });
     }

--- a/jwt-servlet-auth-servlet5/pom.xml
+++ b/jwt-servlet-auth-servlet5/pom.xml
@@ -47,6 +47,12 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.valfirst</groupId>
+            <artifactId>slf4j-test</artifactId>
+            <version>${dependency.slf4j-test}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jwt-servlet-auth-servlet5/src/main/java/io/telicent/servlet/auth/jwt/servlet5/JwtAuthFilter.java
+++ b/jwt-servlet-auth-servlet5/src/main/java/io/telicent/servlet/auth/jwt/servlet5/JwtAuthFilter.java
@@ -17,9 +17,11 @@ package io.telicent.servlet.auth.jwt.servlet5;
 
 import io.telicent.servlet.auth.jwt.AbstractConfigurableJwtAuthFilter;
 import io.telicent.servlet.auth.jwt.JwtAuthenticationEngine;
+import io.telicent.servlet.auth.jwt.JwtLoggingConstants;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
 
 import java.io.IOException;
 
@@ -70,6 +72,10 @@ public class JwtAuthFilter extends AbstractConfigurableJwtAuthFilter<HttpServlet
                 filterChain.doFilter(req, resp);
             } catch (Throwable e) {
                 throw new RuntimeException(e);
+            } finally {
+                // Ensure we remove the authenticated user from the logging context at the end of request processing
+                // otherwise it could leak to subsequent requests and cause them to be logged against the wrong user
+                MDC.remove(JwtLoggingConstants.MDC_JWT_USER);
             }
         });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
         <dependency.servlet3>3.1.0</dependency.servlet3>
         <dependency.servlet5>5.0.0</dependency.servlet5>
         <dependency.slf4j>2.0.18</dependency.slf4j>
+        <dependency.slf4j-test>3.0.3</dependency.slf4j-test>
         <dependency.testng>7.12.0</dependency.testng>
     </properties>
 


### PR DESCRIPTION
In some circumstances the Logging MDC did not have the authenticated username properly cleared from it meaning that later logging statements could be attributed to the wrong user.  This commit ensures that the Logging MDC is appropriately cleared of username at the end of request processing, as well as at the beginning of authentication as was already done.

The main edge case here that this fixes applies to deployments where a request is rejected (for whatever reason) prior to it reaching the `JwtAuthFilter`.  Where `JwtAuthFilter` is the first filter encountered this is generally not a problem, but in cases where other filters/logic may apply prior to filters being invoked, e.g. JAX-RS request matching, then this could be reproduced.