### PR TITLE
Disable publishing internal artifacts (CORE-1353)

### DIFF
--- a/jwt-servlet-auth-benchmarks/pom.xml
+++ b/jwt-servlet-auth-benchmarks/pom.xml
@@ -15,6 +15,12 @@
 
     <properties>
         <license.header.path>${project.parent.basedir}</license.header.path>
+
+        <!-- Only for internal use, not for deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <cyclonedx.skip>true</cyclonedx.skip>
+        <skipPublishing>true</skipPublishing>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <dependencies>

--- a/jwt-servlet-auth-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/pom.xml
@@ -12,6 +12,12 @@
 
     <properties>
         <license.header.path>${project.parent.basedir}</license.header.path>
+
+        <!-- Don't bother deploying these as part of releases, nor do they need SBOMs -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <cyclonedx.skip>true</cyclonedx.skip>
+        <skipPublishing>true</skipPublishing>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -464,7 +464,7 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
+                    <waitUntil>validated</waitUntil>
                     <!-- Central Publishing can be much slower than old Nexus publishing process -->
                     <waitMaxTime>3600</waitMaxTime>
                 </configuration>


### PR DESCRIPTION
Don't publish integration test and benchmark artifacts to Maven Central, also skip other related activities like SBOMs, GPG signatures which are irrelevant to those.