### PR TITLE
Use named Maven Central deployments and further reduce release size

### DIFF
--- a/jwt-servlet-auth-aws/pom.xml
+++ b/jwt-servlet-auth-aws/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <license.header.path>${project.parent.basedir}</license.header.path>
+        <skip.testJars>false</skip.testJars>
     </properties>
 
     <dependencies>

--- a/jwt-servlet-auth-core/pom.xml
+++ b/jwt-servlet-auth-core/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <license.header.path>${project.parent.basedir}</license.header.path>
         <coverage.minimum>0.9</coverage.minimum>
+        <skip.testJars>false</skip.testJars>
     </properties>
 
     <dependencies>

--- a/jwt-servlet-auth-integration-tests/jwt-servlet-auth-common-integration-tests/pom.xml
+++ b/jwt-servlet-auth-integration-tests/jwt-servlet-auth-common-integration-tests/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <license.header.path>${project.parent.parent.basedir}</license.header.path>
+        <skip.testJars>false</skip.testJars>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.telicent.public</groupId>
@@ -252,14 +253,14 @@
                 <groupId>org.openjdk.jmh</groupId>
                 <artifactId>jmh-core</artifactId>
                 <version>${dependency.jmh}</version>
-<!--                <scope>test</scope>-->
+                <!--                <scope>test</scope>-->
             </dependency>
 
             <dependency>
                 <groupId>org.openjdk.jmh</groupId>
                 <artifactId>jmh-generator-annprocess</artifactId>
                 <version>${dependency.jmh}</version>
-<!--                <scope>test</scope>-->
+                <!--                <scope>test</scope>-->
             </dependency>
         </dependencies>
 
@@ -383,7 +384,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${plugin.javadoc}</version>
-                <configuration />
+                <configuration/>
                 <executions>
                     <execution>
                         <goals>
@@ -404,7 +405,9 @@
                     <includes>
                         <include>**/Test*.java</include>
                     </includes>
-                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -XX:+EnableDynamicAgentLoading -Xshare:off</argLine>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -XX:+EnableDynamicAgentLoading
+                        -Xshare:off
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -467,6 +470,7 @@
                     <waitUntil>validated</waitUntil>
                     <!-- Central Publishing can be much slower than old Nexus publishing process -->
                     <waitMaxTime>3600</waitMaxTime>
+                    <deploymentName>JWT Servlet Auth ${project.version}</deploymentName>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,7 @@
                 <configuration>
                     <outputName>${project.artifactId}-${project.version}-bom</outputName>
                     <skipNotDeployed>false</skipNotDeployed>
+                    <outputFormat>json</outputFormat>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,13 @@
         <coverage.minimum>0.8</coverage.minimum>
         <coverage.skip>false</coverage.skip>
 
+        <!-- Whether tests and test-sources JARs are skipped -->
+        <!--
+        These are skipped by default, any module that needs to expose code to downstream consumers can override this
+        property to false in order to produce those JARs
+        -->
+        <skip.testJars>true</skip.testJars>
+
         <!-- Plugin Versions -->
         <plugin.central>0.11.0</plugin.central>
         <plugin.clean>3.1.0</plugin.clean>
@@ -358,6 +365,10 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <skipIfEmpty>true</skipIfEmpty>
+                            <skip>${skip.testJars}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -373,8 +384,17 @@
                         <phase>package</phase>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>attach-test-sources</id>
+                        <phase>package</phase>
+                        <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <skipSource>${skip.testJars}</skipSource>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -471,6 +491,7 @@
                     <!-- Central Publishing can be much slower than old Nexus publishing process -->
                     <waitMaxTime>3600</waitMaxTime>
                     <deploymentName>JWT Servlet Auth ${project.version}</deploymentName>
+                    <checksums>required</checksums>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
See telicent-oss/smart-caches-core#341 for named deployment context

Additionally:

- Don't produce `tests` and `test-sources` JARs for modules where the test code isn't reused downstream from the original module
- Only produce the minimum required checksum files when publishing