### PR TITLE
Adjust AWS ELB Key Resolver tests

### DIFF
--- a/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/AbstractAwsKeyResolverTests.java
+++ b/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/AbstractAwsKeyResolverTests.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.servlet.auth.jwt.verifier.aws;
+
+import io.jsonwebtoken.Identifiable;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.JwkSet;
+import io.jsonwebtoken.security.JwkSetBuilder;
+import io.jsonwebtoken.security.Jwks;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+
+import java.security.KeyPair;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public abstract class AbstractAwsKeyResolverTests {
+    private static final AtomicInteger TEST_PORT = new AtomicInteger(24542);
+    protected AwsElbServer keyServer;
+    protected JwkSet jwks;
+    private Object[][] keyIds;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        List<KeyPair> keyPairs = List.of(Jwts.SIG.ES256.keyPair().build(), Jwts.SIG.ES384.keyPair().build(),
+                                         Jwts.SIG.ES512.keyPair().build());
+        JwkSetBuilder privateJwks = Jwks.set();
+        JwkSetBuilder publicJwks = Jwks.set();
+        keyPairs.forEach(p -> {
+            privateJwks.add(Jwks.builder().keyPair(p).idFromThumbprint().build());
+            publicJwks.add(Jwks.builder().key(p.getPublic()).idFromThumbprint().build());
+        });
+        this.jwks = privateJwks.build();
+
+        this.keyIds = new Object[keyPairs.size()][];
+        for (int i = 0; i < this.jwks.getKeys().size(); i++) {
+            this.keyIds[i] =
+                    new Object[] { this.jwks.getKeys().stream().skip(i).map(Identifiable::getId).findFirst().orElse(null) };
+        }
+
+        this.keyServer = new AwsElbServer(TEST_PORT.getAndIncrement(), publicJwks.build());
+        this.keyServer.start();
+    }
+
+    @AfterMethod
+    public void testCleanup() {
+        AwsElbKeyUrlRegistry.reset();
+    }
+
+    @AfterClass
+    public void teardown() throws Exception {
+        this.keyServer.stop();
+    }
+
+    @DataProvider(name = "keyIds")
+    public Object[][] keyIds() {
+        return this.keyIds;
+    }
+}

--- a/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/AwsElbServer.java
+++ b/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/AwsElbServer.java
@@ -21,7 +21,6 @@ import io.telicent.servlet.auth.jwt.verification.jwks.JwksServer;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Strings;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
@@ -29,6 +28,7 @@ import org.eclipse.jetty.server.Server;
 
 import java.io.IOException;
 import java.util.Base64;
+import java.util.Objects;
 
 /**
  * A mock ELB Key Server for testing
@@ -78,7 +78,7 @@ public class AwsElbServer extends JwksServer {
 
             Jwk<?> jwk = this.jwks.getKeys()
                                   .stream()
-                                  .filter(k -> Strings.CS.equals(k.getId(), keyId))
+                                  .filter(k -> Objects.equals(k.getId(), keyId))
                                   .findFirst()
                                   .orElse(null);
 

--- a/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/TestAwsElbKeyResolver.java
+++ b/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/TestAwsElbKeyResolver.java
@@ -17,29 +17,66 @@ package io.telicent.servlet.auth.jwt.verifier.aws;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.InvalidKeyException;
+import io.jsonwebtoken.security.Jwk;
 import io.telicent.servlet.auth.jwt.verification.SignedJwtVerifier;
 import org.apache.commons.lang3.Strings;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.security.Key;
+import java.sql.Date;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
 
 import static org.mockito.Mockito.*;
 
-public class TestAwsElbKeyResolver {
+public class TestAwsElbKeyResolver extends AbstractAwsKeyResolverTests {
 
     public static final String TEST_AWS_REGION = "eu-west-1";
-
-    private static final String TEST_AWS_ELB_KEY_ID = "00770e84-91d7-4a1d-bab7-2fbe9de4b5ab";
-
-    private static final String TEST_JWT =
-            "eyJ0eXAiOiJKV1QiLCJraWQiOiIwMDc3MGU4NC05MWQ3LTRhMWQtYmFiNy0yZmJlOWRlNGI1YWIiLCJhbGciOiJFUzI1NiIsImlzcyI6Imh0dHBzOi8vY29nbml0by1pZHAuZXUtd2VzdC0xLmFtYXpvbmF3cy5jb20vZXUtd2VzdC0xX0hSMWMxWGozTiIsImNsaWVudCI6IjU2NXZqOW42ZnQ5b2ZicnFvbTA5NW10cWIiLCJzaWduZXIiOiJhcm46YXdzOmVsYXN0aWNsb2FkYmFsYW5jaW5nOmV1LXdlc3QtMTowOTg2Njk1ODk1NDE6bG9hZGJhbGFuY2VyL2FwcC9UZWxpYy1BcHBsaS02TDhBMFhPVkJQOFgvMGQ0MzA0NWI3NmVlNjFhNSIsImV4cCI6MTY1NDYxNjkxOH0=.eyJzdWIiOiI1Zjc0ZmNjYS1jZjBhLTRjZGQtOGM4ZC1iZmM4NjhjYWY0NGMiLCJlbWFpbF92ZXJpZmllZCI6InRydWUiLCJlbWFpbCI6InRvbUB0ZWxpY2VudC5pbyIsInVzZXJuYW1lIjoiNWY3NGZjY2EtY2YwYS00Y2RkLThjOGQtYmZjODY4Y2FmNDRjIiwiZXhwIjoxNjU0NjE2OTE4LCJpc3MiOiJodHRwczovL2NvZ25pdG8taWRwLmV1LXdlc3QtMS5hbWF6b25hd3MuY29tL2V1LXdlc3QtMV9IUjFjMVhqM04ifQ==.SdlxvcVug6g4xM6seIUIfsq56CW4A9aZynvlWmT3ry939KgrZc9JXoYe9zBVptPxs_7FHkFzBSfocAp4A7I1Mg==";
 
     private Key verifyKeyResolution(String region, String keyId) {
         AwsElbKeyResolver resolver = new AwsElbKeyResolver(region);
         JwsHeader header = mock(JwsHeader.class);
         when(header.getKeyId()).thenReturn(keyId);
         return resolver.locate(header);
+    }
+
+    @BeforeMethod
+    public void testSetup() {
+        // August 2026 - AWS changed something that means the previous Test Key ID we used no longer resolved (produces
+        //               a 403 error) so have to use a fake key server instead which is less than ideal but we don't
+        //               have a good way to reliably get an AWS Key ID that we can reliably access outside AWS infra
+        AwsElbKeyUrlRegistry.register(TEST_AWS_REGION, this.keyServer.getUrl() + "/%s");
+    }
+
+    /**
+     * Gets the Test Key ID in use
+     *
+     * @return Test Key ID
+     */
+    public String getTestKeyId() {
+        return (String) this.keyIds()[0][0];
+    }
+
+    public String prepareJwt(UnaryOperator<JwtBuilder> customiser) {
+        String testKeyId = getTestKeyId();
+        JwtBuilder builder = Jwts.builder()
+                                 .header()
+                                 .keyId(testKeyId)
+                                 .and()
+                                 .subject("test")
+                                 .expiration(Date.from(
+                                         Instant.now().plusSeconds(15)))
+                                 .signWith(this.jwks.getKeys()
+                                                    .stream()
+                                                    .filter(k -> Objects.equals(k.getId(), testKeyId))
+                                                    .map(Jwk::toKey)
+                                                    .findFirst()
+                                                    .orElse(null));
+        return customiser.apply(builder).compact();
     }
 
     @Test(expectedExceptions = InvalidKeyException.class)
@@ -64,7 +101,7 @@ public class TestAwsElbKeyResolver {
     @Test
     public void givenValidRegionAndKey_whenResolving_thenSuccess() {
         // Given and When
-        Key key = verifyKeyResolution(TEST_AWS_REGION, TEST_AWS_ELB_KEY_ID);
+        Key key = verifyKeyResolution(TEST_AWS_REGION, getTestKeyId());
 
         // Then
         Assert.assertNotNull(key);
@@ -75,18 +112,20 @@ public class TestAwsElbKeyResolver {
         // Given
         AwsElbKeyResolver resolver = new AwsElbKeyResolver(TEST_AWS_REGION);
         SignedJwtVerifier verifier = new SignedJwtVerifier(resolver);
+        String jwt = prepareJwt(b -> b.expiration(Date.from(Instant.now().minusSeconds(10))));
 
         // When and Then
-        verifier.verify(TEST_JWT);
+        verifier.verify(jwt);
     }
 
     @Test(expectedExceptions = ExpiredJwtException.class)
     public void givenExpiredJwt_whenResolving_thenError() {
         // Given
         AwsElbJwtVerifier verifier = new AwsElbJwtVerifier(TEST_AWS_REGION);
+        String jwt = prepareJwt(b -> b.expiration(Date.from(Instant.now().minusSeconds(10))));
 
         // When and Then
-        verifier.verify(TEST_JWT);
+        verifier.verify(jwt);
     }
 
     @Test
@@ -94,12 +133,13 @@ public class TestAwsElbKeyResolver {
         // Given
         AwsElbKeyResolver resolver = new AwsElbKeyResolver(TEST_AWS_REGION);
         SignedJwtVerifier verifier = new SignedJwtVerifier(Jwts.parser().keyLocator(resolver)
-                                                               // We know the test JWT has long expired but want to verify that if we ignore the expiry we can
+                                                               // We know the test JWT has expired but want to verify that if we ignore the expiry we can
                                                                // successfully verify.  We're setting the largest possible clock skew here to achieve this.
                                                                .clockSkewSeconds(Long.MAX_VALUE / 1000).build());
+        String jwt = prepareJwt(b -> b.expiration(Date.from(Instant.now().minusSeconds(10))));
 
         // When and Then
-        Jws<Claims> jws = verifier.verify(TEST_JWT);
+        Jws<Claims> jws = verifier.verify(jwt);
         Assert.assertNotNull(jws);
     }
 

--- a/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/TestAwsElbKeyUrlRegistry.java
+++ b/jwt-servlet-auth-aws/src/test/java/io/telicent/servlet/auth/jwt/verifier/aws/TestAwsElbKeyUrlRegistry.java
@@ -33,51 +33,7 @@ import static io.telicent.servlet.auth.jwt.verifier.aws.TestAwsElbKeyResolver.TE
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TestAwsElbKeyUrlRegistry {
-
-    private AwsElbServer keyServer;
-    private JwkSet jwks;
-
-    private Object[][] keyIds;
-
-    private static final AtomicInteger TEST_PORT = new AtomicInteger(35791);
-
-    @BeforeClass
-    public void setup() throws Exception {
-        List<KeyPair> keyPairs = List.of(Jwts.SIG.ES256.keyPair().build(), Jwts.SIG.ES384.keyPair().build(),
-                                         Jwts.SIG.ES512.keyPair().build());
-        JwkSetBuilder privateJwks = Jwks.set();
-        JwkSetBuilder publicJwks = Jwks.set();
-        keyPairs.forEach(p -> {
-            privateJwks.add(Jwks.builder().keyPair(p).idFromThumbprint().build());
-            publicJwks.add(Jwks.builder().key(p.getPublic()).idFromThumbprint().build());
-        });
-        this.jwks = privateJwks.build();
-
-        this.keyIds = new Object[keyPairs.size()][];
-        for (int i = 0; i < this.jwks.getKeys().size(); i++) {
-            this.keyIds[i] =
-                    new Object[] { this.jwks.getKeys().stream().skip(i).map(k -> k.getId()).findFirst().orElse(null) };
-        }
-
-        this.keyServer = new AwsElbServer(TEST_PORT.getAndIncrement(), publicJwks.build());
-        this.keyServer.start();
-    }
-
-    @AfterMethod
-    public void testCleanup() {
-        AwsElbKeyUrlRegistry.reset();
-    }
-
-    @AfterClass
-    public void teardown() throws Exception {
-        this.keyServer.stop();
-    }
-
-    @DataProvider(name = "keyIds")
-    public Object[][] keyIds() {
-        return this.keyIds;
-    }
+public class TestAwsElbKeyUrlRegistry extends AbstractAwsKeyResolverTests {
 
     @Test
     public void givenNormalRegion_whenLookingUpKeys_thenDefaultUrlIsUsed() {

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- SonarQube analysis, invoked from CI via mvn sonar:sonar -->
-        <sonar.projectKey>telicent-jwt-auth</sonar.projectKey>
+        <sonar.projectKey>telicent-oss_jwt-auth</sonar.projectKey>
 
         <!-- License Plugin Configuration -->
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,9 @@
         <jdk.version>21</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- SonarQube analysis, invoked from CI via mvn sonar:sonar -->
+        <sonar.projectKey>telicent-jwt-auth</sonar.projectKey>
+
         <!-- License Plugin Configuration -->
         <!--
         Note that all sub-modules need to declare this appropriately as well so that the plugin can correctly find
@@ -97,6 +100,7 @@
         <plugin.nexus>1.7.0</plugin.nexus>
         <plugin.release>3.3.1</plugin.release>
         <plugin.shade>3.2.4</plugin.shade>
+        <plugin.sonar>5.7.0.6970</plugin.sonar>
         <plugin.source>3.4.0</plugin.source>
         <plugin.surefire>3.5.6</plugin.surefire>
         <plugin.versions>2.21.0</plugin.versions>
@@ -605,6 +609,12 @@
                     <configuration>
                         <ignoredVersions>.*[-\.]M.*,.*-alpha.*,.*-beta.*,.*-RC.*,.*rc.*</ignoredVersions>
                     </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.sonarsource.scanner.maven</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>${plugin.sonar}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
AWS changed something that means the public AWS ELB Key IDs no longer resolve (at least not externally to AWS infrastructure) so changing the test to use mocked server instead